### PR TITLE
Add support for yoked and non-yoked camera

### DIFF
--- a/camera.js
+++ b/camera.js
@@ -38,11 +38,11 @@ Camera.prototype.keyboardInput = function(keyboard){
   }
 
   if ('W' in keyboard.keysDown){
-    this.velocity.y = this.speed;
+    this.velocity.y = -this.speed;
   }
 
   if ('S' in keyboard.keysDown){
-    this.velocity.y = -this.speed;
+    this.velocity.y = this.speed;
   }
 
   if ('.' in keyboard.keysDown){

--- a/camera.js
+++ b/camera.js
@@ -14,6 +14,7 @@ function Camera(options){
   this.orientation = options.orientation
   this.speed = options.speed
   this.friction = options.friction
+  this.yoked = options.yoked
   this.velocity = {
     x: options.velocity.x,
     y: options.velocity.y,
@@ -29,11 +30,11 @@ Camera.prototype.move = function(velocity) {
 
 Camera.prototype.keyboardInput = function(keyboard){
   if ('A' in keyboard.keysDown){
-    this.velocity.x = this.speed;
+    this.velocity.x = -this.speed;
   }
 
   if ('D' in keyboard.keysDown){
-    this.velocity.x = -this.speed;
+    this.velocity.x = this.speed;
   }
 
   if ('W' in keyboard.keysDown){

--- a/center.js
+++ b/center.js
@@ -6,20 +6,20 @@ module.exports = Center
 
 function Center(options){
   options = options || {}
-  this.size = options.size || 0.2
+  this.size = options.size || 2
   this.color = options.color || "#DFE0E2"
 }
 
 Center.prototype.border = function(transform) {
   var self = this
   var points = _.range(7).map(function(i) {
-    var dx = self.size * transform.scale * Math.cos(i * 2 * Math.PI / 6)
-    var dy = self.size * transform.scale * Math.sin(i * 2 * Math.PI / 6)
+    var dx = self.size * .1 * transform.scale * Math.cos(i * 2 * Math.PI / 6)
+    var dy = self.size * .1 * transform.scale * Math.sin(i * 2 * Math.PI / 6)
     return [dx, dy]
   })
   points = math.multiply(points, transform.rotation)
   return points.map(function(v) {
-    return math.add(v,[transform.position.x, transform.position.y])
+    return math.add(v,[transform.position.x + game.width/2, transform.position.y + game.height/2])
   })
 }
 

--- a/game.js
+++ b/game.js
@@ -20,7 +20,7 @@ var player = new Player({
   orientation: 0,
   size: { x: 2, y: 2 },
   velocity: { x: 0, y: 0 },
-  speed: 1,
+  speed: .7,
   friction: 0.9,
   color: '#EB7576'
 });
@@ -68,8 +68,8 @@ game.on('update', function(interval){
 
 game.on('draw', function(context){
   if (camera.yoked){
-    camera.position.x = player.position.x
-    camera.position.y = player.position.y 
+    camera.position.x = player.position.x * 0.1 * camera.position.z
+    camera.position.y = player.position.y * 0.1 * camera.position.z
     camera.orientation = player.orientation
   }
   world.render(context, camera)

--- a/game.js
+++ b/game.js
@@ -26,13 +26,13 @@ var player = new Player({
 });
 
 var camera = new Camera({
-  position: {x: 0, y:0, z: 20},
+  position: {x: 0, y:0, z: 80},
   orientation: 0,
   speed: 2,
   velocity: 0,
   friction: 0.9,
   velocity: { x: 0, y: 0, z: 0},
-  yoked: true
+  yoked: false
 })
 
 player.addTo(game)

--- a/game.js
+++ b/game.js
@@ -32,7 +32,7 @@ var camera = new Camera({
   velocity: 0,
   friction: 0.9,
   velocity: { x: 0, y: 0, z: 0},
-  yoked: 1
+  yoked: true
 })
 
 player.addTo(game)

--- a/game.js
+++ b/game.js
@@ -16,22 +16,23 @@ var mouse = new Mouse(game)
 var world = new World()
 
 var player = new Player({
-  position: { x: game.width/2, y: game.height/2 },
+  position: { x: 0, y: 0 },
   orientation: 0,
-  size: { x: 10, y: 10 },
+  size: { x: 2, y: 2 },
   velocity: { x: 0, y: 0 },
-  speed: 2,
+  speed: 1,
   friction: 0.9,
   color: '#EB7576'
 });
 
 var camera = new Camera({
-  position: {x: game.width/2, y:game.height/2, z: 1},
+  position: {x: 0, y:0, z: 20},
   orientation: 0,
   speed: 2,
   velocity: 0,
   friction: 0.9,
-  velocity: { x: 0, y: 0, z: 0}
+  velocity: { x: 0, y: 0, z: 0},
+  yoked: 1
 })
 
 player.addTo(game)
@@ -66,6 +67,11 @@ game.on('update', function(interval){
 
 
 game.on('draw', function(context){
+  if (camera.yoked){
+    camera.position.x = player.position.x
+    camera.position.y = player.position.y 
+    camera.orientation = player.orientation
+  }
   world.render(context, camera)
   player.render(context, camera)
 });

--- a/game.js
+++ b/game.js
@@ -32,7 +32,7 @@ var camera = new Camera({
   velocity: 0,
   friction: 0.9,
   velocity: { x: 0, y: 0, z: 0},
-  yoked: false
+  yoked: true
 })
 
 player.addTo(game)

--- a/path.js
+++ b/path.js
@@ -22,7 +22,7 @@ Path.prototype.border = function(transform) {
   ]
   points = math.multiply(points, transform.rotation)
   return points.map(function(v) {
-    return math.add(v,[transform.position.x, transform.position.y])
+    return math.add(v,[transform.position.x + game.width/2, transform.position.y + game.height/2])
   })
 }
 

--- a/player.js
+++ b/player.js
@@ -80,12 +80,12 @@ Player.prototype.keyboardInput = function(keyboard){
   }
 
   if ('J' in keyboard.keysDown){
-    this.orientation -= this.speed*.9
+    this.orientation -= this.speed*1.9
     if (this.orientation < 0) this.orientation = 360
   }
 
   if ('L' in keyboard.keysDown){
-    this.orientation += this.speed*.9
+    this.orientation += this.speed*1.9
     if (this.orientation > 360) this.orientation = 0
   }
 }

--- a/player.js
+++ b/player.js
@@ -45,20 +45,20 @@ Player.prototype.move = function(velocity){
 };
 
 Player.prototype.checkBoundaries = function(){
-  if (this.position.x <= -this.game.width/2* + this.size.x){
-    this.position.x = -this.game.width/2 + this.size.x;
+  if (this.position.x <= -this.game.width/4 + this.size.x){
+    this.position.x = -this.game.width/4 + this.size.x;
   }
 
-  if (this.position.x >= this.game.width/2 - this.size.x){
-    this.position.x = this.game.width/2 - this.size.x;
+  if (this.position.x >= this.game.width/4 - this.size.x){
+    this.position.x = this.game.width/4 - this.size.x;
   }
 
-  if (this.position.y <= -this.game.height/2 + this.size.y){
-    this.position.y = -this.game.height/2 + this.size.y;
+  if (this.position.y <= -this.game.height/4 + this.size.y){
+    this.position.y = -this.game.height/4 + this.size.y;
   }
 
-  if (this.position.y >= this.game.height/2 - this.size.y){
-    this.position.y = this.game.height/2 - this.size.y;
+  if (this.position.y >= this.game.height/4 - this.size.y){
+    this.position.y = this.game.height/4 - this.size.y;
   }
 };
 
@@ -80,12 +80,12 @@ Player.prototype.keyboardInput = function(keyboard){
   }
 
   if ('J' in keyboard.keysDown){
-    this.orientation -= 0.8
+    this.orientation -= this.speed*.9
     if (this.orientation < 0) this.orientation = 360
   }
 
   if ('L' in keyboard.keysDown){
-    this.orientation += 0.8
+    this.orientation += this.speed*.9
     if (this.orientation > 360) this.orientation = 0
   }
 }
@@ -95,7 +95,7 @@ Player.prototype.render = function(context, camera) {
   var self = this
   var angle = camera.orientation * Math.PI / 180
   var scale = 0.1 * camera.position.z
-  var position = [self.position.x, self.position.y]
+  var position = [self.position.x*scale, self.position.y*scale]
   var rotation = [[Math.cos(angle), -Math.sin(angle)], [Math.sin(angle), Math.cos(angle)]] 
 
   position[0] = position[0] - camera.position.x

--- a/player.js
+++ b/player.js
@@ -40,32 +40,34 @@ Player.prototype.move = function(velocity){
   var angle = this.orientation * Math.PI / 180
   this.position.x += velocity.x*Math.cos(angle)-velocity.y*Math.sin(angle);
   this.position.y += velocity.x*Math.sin(angle)+velocity.y*Math.cos(angle);
+//  this.position.x += velocity.x;
+//  this.position.y += velocity.y;
 };
 
 Player.prototype.checkBoundaries = function(){
-  if (this.position.x <= 0){
-    this.position.x = 0;
+  if (this.position.x <= -this.game.width/2* + this.size.x){
+    this.position.x = -this.game.width/2 + this.size.x;
   }
 
-  if (this.position.x >= this.game.width - this.size.x){
-    this.position.x = this.game.width - this.size.x;
+  if (this.position.x >= this.game.width/2 - this.size.x){
+    this.position.x = this.game.width/2 - this.size.x;
   }
 
-  if (this.position.y <= 0){
-    this.position.y = 0;
+  if (this.position.y <= -this.game.height/2 + this.size.y){
+    this.position.y = -this.game.height/2 + this.size.y;
   }
 
-  if (this.position.y >= this.game.height - this.size.y){
-    this.position.y = this.game.height - this.size.y;
+  if (this.position.y >= this.game.height/2 - this.size.y){
+    this.position.y = this.game.height/2 - this.size.y;
   }
 };
 
 Player.prototype.keyboardInput = function(keyboard){
-  if ('L' in keyboard.keysDown){
+  if ('O' in keyboard.keysDown){
     this.velocity.x = this.speed;
   }
 
-  if ('J' in keyboard.keysDown){
+  if ('U' in keyboard.keysDown){
     this.velocity.x = -this.speed;
   }
 
@@ -77,13 +79,13 @@ Player.prototype.keyboardInput = function(keyboard){
     this.velocity.y = -this.speed;
   }
 
-  if ('U' in keyboard.keysDown){
-    this.orientation -= 0.7
+  if ('J' in keyboard.keysDown){
+    this.orientation -= 0.8
     if (this.orientation < 0) this.orientation = 360
   }
 
-  if ('O' in keyboard.keysDown){
-    this.orientation += 0.7
+  if ('L' in keyboard.keysDown){
+    this.orientation += 0.8
     if (this.orientation > 360) this.orientation = 0
   }
 }
@@ -91,35 +93,50 @@ Player.prototype.keyboardInput = function(keyboard){
 Player.prototype.render = function(context, camera) {
 
   var self = this
-  var angle = self.orientation * Math.PI / 180
-    
+  var angle = camera.orientation * Math.PI / 180
+  var scale = 0.1 * camera.position.z
+  var position = [self.position.x, self.position.y]
+  var rotation = [[Math.cos(angle), -Math.sin(angle)], [Math.sin(angle), Math.cos(angle)]] 
+
+  position[0] = position[0] - camera.position.x
+  position[1] = position[1] - camera.position.y
+  var position = math.multiply(position, rotation)
+
+  var originX = position[0] + game.width/2
+  var originY = position[1] + game.height/2
+
+//  var originX = position[0] - camera.position.x+game.width/2
+//  var originY = position[1] - camera.position.y+game.height/2
+  
+  angle = self.orientation * Math.PI / 180 - angle
+
   context.lineWidth = 3
 
   // ears
-  var x = -5
-  var y = -10
+  var x = -this.size.x/2
+  var y = -this.size.y
   var dx = x*Math.cos(angle)-y*Math.sin(angle)
   var dy = x*Math.sin(angle)+y*Math.cos(angle)
   context.beginPath()
   context.fillStyle = '#EB8686'
-  context.ellipse(self.position.x + dx, self.position.y + dy, 13, 6, angle + 45* Math.PI/180, 0, 2*Math.PI)
+  context.ellipse(originX + scale*dx, originY + scale*dy, scale*this.size.x*1.3, scale*this.size.x*.6, angle + 45* Math.PI/180, 0, 2*Math.PI)
   context.closePath()
   context.fill()
 
-  var x = 5
-  var y = -10
+  var x = this.size.x/2
+  var y = -this.size.y
   var dx = x*Math.cos(angle)-y*Math.sin(angle)
   var dy = x*Math.sin(angle)+y*Math.cos(angle)
   context.beginPath()
   context.fillStyle = '#EB8686'
-  context.ellipse(self.position.x + dx, self.position.y + dy, 13, 6, angle - 45 * Math.PI/180, 0, 2*Math.PI)
+  context.ellipse(originX + scale*dx, originY + scale*dy, scale*this.size.x*1.3, scale*this.size.x*.6, angle - 45 * Math.PI/180, 0, 2*Math.PI)
   context.closePath()
   context.fill()
 
   // body
   context.beginPath() 
   context.fillStyle = '#EC6A6A'
-  context.arc(self.position.x, self.position.y, 15, 0, 2*Math.PI)
+  context.arc(originX, originY, scale*this.size.x*1.5, 0, 2*Math.PI)
   context.closePath()
   context.fill()
 

--- a/tile.js
+++ b/tile.js
@@ -23,9 +23,13 @@ Tile.prototype.transform = function(camera) {
   var y = scale * Math.sqrt(3) * (this.position.q + this.position.r/2)
   var angle = camera.orientation * Math.PI / 180
   var rotation = [[Math.cos(angle), -Math.sin(angle)], [Math.sin(angle), Math.cos(angle)]] 
+  x = x - camera.position.x
+  y = y - camera.position.y
   var position = math.multiply([x, y], rotation)
-  x = position[0] + camera.position.x
-  y = position[1] + camera.position.y
+  x = position[0]
+  y = position[1]
+  //x = position[0] - camera.position.x
+  //y = position[1] - camera.position.y
   return {position: {x: x, y: y}, scale: scale, rotation: rotation}
 
 }
@@ -39,7 +43,7 @@ Tile.prototype.border = function(transform) {
   })
   points = math.multiply(points, transform.rotation)
   return points.map(function(v) {
-    return math.add(v,[transform.position.x, transform.position.y])
+    return math.add(v,[transform.position.x + game.width/2, transform.position.y + game.height/2])
   })
 }
 


### PR DESCRIPTION
This pull request adds support for a yoked and non-yoked camera inside the camera object.

When non-yoked the camera position and orientation can be controlled via the WASD+QE keys. The player can be controlled with IJKL (JL rotation)

When yoked the camera is locked above the player, which is controlled with IJKL

In both cases the camera can still zoom independently
