### PR TITLE
Refactor transforms and geometry

### DIFF
--- a/camera.js
+++ b/camera.js
@@ -1,11 +1,13 @@
 var inherits = require('inherits');
 var aabb = require('aabb-2d');
 var Entity = require('crtrdg-entity');
+var Transform = require('./transform.js')
 
 module.exports = Camera;
 inherits(Camera, Entity);
 
 function Camera(options){
+  var self = this
   this.position = { 
     x: options.position.x, 
     y: options.position.y,
@@ -20,12 +22,23 @@ function Camera(options){
     y: options.velocity.y,
     z: options.velocity.z
   }
+  this.transform = new Transform({
+    position: {x: -self.position.x, y: -self.position.y}, 
+    scale: self.position.z,
+    rotation: self.orientation
+  })
 }
 
 Camera.prototype.move = function(velocity) {
+  var self = this
   this.position.x += velocity.x
   this.position.y += velocity.y
   this.position.z += velocity.z * 0.1
+  this.transform.update({
+    position: {x: -self.position.x +this.game.width/2, y: -self.position.y +this.game.height/2}, 
+    scale: self.position.z, 
+    rotation: self.orientation})
+  console.log(this.transform.position)
 }
 
 Camera.prototype.keyboardInput = function(keyboard){

--- a/camera.js
+++ b/camera.js
@@ -13,7 +13,7 @@ function Camera(options){
     y: options.position.y,
     z: options.position.z
   }
-  this.orientation = options.orientation
+  this.rotation = options.rotation
   this.speed = options.speed
   this.friction = options.friction
   this.yoked = options.yoked
@@ -25,7 +25,7 @@ function Camera(options){
   this.transform = new Transform({
     position: {x: -self.position.x, y: -self.position.y}, 
     scale: self.position.z,
-    rotation: self.orientation
+    rotation: self.rotation
   })
 }
 
@@ -37,8 +37,7 @@ Camera.prototype.move = function(velocity) {
   this.transform.update({
     position: {x: -self.position.x +this.game.width/2, y: -self.position.y +this.game.height/2}, 
     scale: self.position.z, 
-    rotation: self.orientation})
-  console.log(this.transform.position)
+    rotation: self.rotation})
 }
 
 Camera.prototype.keyboardInput = function(keyboard){
@@ -67,12 +66,12 @@ Camera.prototype.keyboardInput = function(keyboard){
   }
 
   if ('U' in keyboard.keysDown){
-    this.orientation -= 0.1
-    if (this.orientation < 0) this.orientation = 360
+    this.rotation -= 0.1
+    if (this.rotation < 0) this.rotation = 360
   }
 
   if ('O' in keyboard.keysDown){
-    this.orientation += 0.1
-    if (this.orientation > 360) this.orientation = 0
+    this.rotation += 0.1
+    if (this.rotation > 360) this.rotation = 0
   }
 }

--- a/camera.js
+++ b/camera.js
@@ -33,9 +33,9 @@ Camera.prototype.move = function(velocity) {
   var self = this
   this.position.x += velocity.x
   this.position.y += velocity.y
-  this.position.z += velocity.z * 0.1
+  this.position.z = Math.exp(Math.log(this.position.z) + velocity.z * .05)
   this.transform.update({
-    position: {x: -self.position.x +this.game.width/2, y: -self.position.y +this.game.height/2}, 
+    position: {x: self.position.x, y: self.position.y}, 
     scale: self.position.z, 
     rotation: self.rotation})
 }
@@ -58,11 +58,11 @@ Camera.prototype.keyboardInput = function(keyboard){
   }
 
   if ('.' in keyboard.keysDown){
-    this.velocity.z = this.speed
+    this.velocity.z = -this.speed
   }
 
   if (',' in keyboard.keysDown){
-    this.velocity.z = -this.speed
+    this.velocity.z = this.speed
   }
 
   if ('U' in keyboard.keysDown){

--- a/camera.js
+++ b/camera.js
@@ -31,8 +31,10 @@ function Camera(options){
 
 Camera.prototype.move = function(velocity) {
   var self = this
-  this.position.x += velocity.x
-  this.position.y += velocity.y
+  var theta = self.rotation * Math.PI / 180
+  var rotation = [[Math.cos(theta), -Math.sin(theta)], [Math.sin(theta), Math.cos(theta)]]
+  this.position.x += velocity.x * rotation[0][0] + velocity.y * rotation[0][1]
+  this.position.y += velocity.x * rotation[1][0] + velocity.y * rotation[1][1]
   this.position.z = Math.exp(Math.log(this.position.z) + velocity.z * .05)
   this.transform.update({
     position: {x: self.position.x, y: self.position.y}, 
@@ -65,12 +67,12 @@ Camera.prototype.keyboardInput = function(keyboard){
     this.velocity.z = this.speed
   }
 
-  if ('U' in keyboard.keysDown){
+  if ('O' in keyboard.keysDown){
     this.rotation -= 0.1
     if (this.rotation < 0) this.rotation = 360
   }
 
-  if ('O' in keyboard.keysDown){
+  if ('U' in keyboard.keysDown){
     this.rotation += 0.1
     if (this.rotation > 360) this.rotation = 0
   }

--- a/center.js
+++ b/center.js
@@ -1,5 +1,4 @@
 _ = require('lodash')
-math = require('mathjs')
 aabb = require('aabb-2d')
 
 module.exports = Center
@@ -10,23 +9,20 @@ function Center(options){
   this.color = options.color || "#DFE0E2"
 }
 
-Center.prototype.border = function(transform) {
+Center.prototype.points = function() {
   var self = this
   var points = _.range(7).map(function(i) {
-    var dx = self.size * .1 * transform.scale * Math.cos(i * 2 * Math.PI / 6)
-    var dy = self.size * .1 * transform.scale * Math.sin(i * 2 * Math.PI / 6)
+    var dx = self.size * .1 * Math.cos(i * 2 * Math.PI / 6)
+    var dy = self.size * .1 * Math.sin(i * 2 * Math.PI / 6)
     return [dx, dy]
   })
-  points = math.multiply(points, transform.rotation)
-  return points.map(function(v) {
-    return math.add(v,[transform.position.x + game.width/2, transform.position.y + game.height/2])
-  })
+  return points
 }
 
 Center.prototype.render = function(context, transform) {
-  var border = this.border(transform)
+  var points = transform.apply(this.points())
   context.beginPath()
-  _.forEach(border, function(point) {
+  _.forEach(points, function(point) {
     context.lineTo(point[0], point[1])
   })
   context.closePath()

--- a/center.js
+++ b/center.js
@@ -22,6 +22,6 @@ Center.prototype.init = function(props) {
   })
   this.points = points
 
-  var scale = (props.scale || 2)
+  var scale = (props.scale || 1.5)
   this.transform = new Transform({scale: scale})
 }

--- a/center.js
+++ b/center.js
@@ -1,39 +1,27 @@
-_ = require('lodash')
-aabb = require('aabb-2d')
+var inherits = require('inherits')
+var Geometry = require('./geometry.js')
+var Transform = require('./transform.js')
 
 module.exports = Center
+inherits(Center, Geometry)
 
-function Center(props){
-  if (!props) props = {}
-  this.parent = props.parent
-  this.size = props.size || 2
-  this.color = props.color || "#DFE0E2"
-  this.init()
+function Center(props, children) {
+  Geometry.call(this, props, children)
 }
 
-Center.prototype.init = function() {
-  var self = this
+Center.prototype.init = function(props) {
+  this.props = {
+    fill: props.fill || '#DFE0E2',
+    stroke: props.stroke || '#DFE0E2'
+  } 
+
   var points = _.range(7).map(function(i) {
-    var dx = self.size * .1 * Math.cos(i * 2 * Math.PI / 6)
-    var dy = self.size * .1 * Math.sin(i * 2 * Math.PI / 6)
+    var dx = .1 * Math.cos(i * 2 * Math.PI / 6)
+    var dy = .1 * Math.sin(i * 2 * Math.PI / 6)
     return [dx, dy]
   })
-  if (this.parent) points = this.parent.transform.apply(points)
   this.points = points
-}
 
-Center.prototype.draw = function(context, points) {
-  context.beginPath()
-  _.forEach(points, function(point) {
-    context.lineTo(point[0], point[1])
-  })
-  context.closePath()
-  context.fillStyle = this.color
-  context.fill()
-}
-
-Center.prototype.render = function(context, camera) {
-  var points = this.points
-  points = camera.transform.apply(points)
-  this.draw(context, points)
+  var scale = (props.scale || 2)
+  this.transform = new Transform({scale: scale})
 }

--- a/center.js
+++ b/center.js
@@ -34,6 +34,10 @@ Center.prototype.draw = function(context, points) {
 
 Center.prototype.render = function(context, camera) {
   var points = this.points
-  points = camera.transform.apply(points)
+  points = camera.transform.invert(points)
+  // translate
+  points = points.map(function(point) {
+    return [point[0] + this.game.width/2, point[1] + this.game.height/2]
+  })
   this.draw(context, points)
 }

--- a/center.js
+++ b/center.js
@@ -1,3 +1,4 @@
+var _ = require('lodash')
 var inherits = require('inherits')
 var Geometry = require('./geometry.js')
 var Transform = require('./transform.js')
@@ -22,6 +23,6 @@ Center.prototype.init = function(props) {
   })
   this.points = points
 
-  var scale = (props.scale || 1.5)
+  var scale = (props.scale || 1.4)
   this.transform = new Transform({scale: scale})
 }

--- a/center.js
+++ b/center.js
@@ -22,9 +22,7 @@ Center.prototype.init = function() {
   this.points = points
 }
 
-Center.prototype.render = function(context, camera) {
-  var points = this.points
-  points = camera.transform.apply(points)
+Center.prototype.draw = function(context, points) {
   context.beginPath()
   _.forEach(points, function(point) {
     context.lineTo(point[0], point[1])
@@ -32,4 +30,10 @@ Center.prototype.render = function(context, camera) {
   context.closePath()
   context.fillStyle = this.color
   context.fill()
+}
+
+Center.prototype.render = function(context, camera) {
+  var points = this.points
+  points = camera.transform.apply(points)
+  this.draw(context, points)
 }

--- a/center.js
+++ b/center.js
@@ -3,24 +3,28 @@ aabb = require('aabb-2d')
 
 module.exports = Center
 
-function Center(options){
-  options = options || {}
-  this.size = options.size || 2
-  this.color = options.color || "#DFE0E2"
+function Center(props){
+  if (!props) props = {}
+  this.parent = props.parent
+  this.size = props.size || 2
+  this.color = props.color || "#DFE0E2"
+  this.init()
 }
 
-Center.prototype.points = function() {
+Center.prototype.init = function() {
   var self = this
   var points = _.range(7).map(function(i) {
     var dx = self.size * .1 * Math.cos(i * 2 * Math.PI / 6)
     var dy = self.size * .1 * Math.sin(i * 2 * Math.PI / 6)
     return [dx, dy]
   })
-  return points
+  if (this.parent) points = this.parent.transform.apply(points)
+  this.points = points
 }
 
-Center.prototype.render = function(context, transform) {
-  var points = transform.apply(this.points())
+Center.prototype.render = function(context, camera) {
+  var points = this.points
+  points = camera.transform.apply(points)
   context.beginPath()
   _.forEach(points, function(point) {
     context.lineTo(point[0], point[1])

--- a/game.js
+++ b/game.js
@@ -32,7 +32,7 @@ var camera = new Camera({
   velocity: 0,
   friction: 0.9,
   velocity: { x: 0, y: 0, z: 0},
-  yoked: false
+  yoked: true
 })
 
 player.addTo(game)
@@ -68,8 +68,8 @@ game.on('update', function(interval){
 
 game.on('draw', function(context){
   if (camera.yoked){
-    camera.position.x = player.position.x * 0.1 * camera.position.z
-    camera.position.y = player.position.y * 0.1 * camera.position.z
+    camera.position.x = player.position.x 
+    camera.position.y = player.position.y
     camera.orientation = player.orientation
   }
   world.render(context, camera)

--- a/game.js
+++ b/game.js
@@ -17,7 +17,7 @@ var world = new World()
 
 var player = new Player({
   position: {x: 0, y: 0},
-  orientation: 0,
+  rotation: 0,
   size: {x: 10, y: 10},
   velocity: {x: 0, y: 0},
   speed: 2,
@@ -27,7 +27,7 @@ var player = new Player({
 
 var camera = new Camera({
   position: {x: 0, y: 0, z: 10},
-  orientation: 0,
+  rotation: 0,
   speed: 1,
   velocity: 0,
   friction: 0.9,

--- a/game.js
+++ b/game.js
@@ -18,17 +18,17 @@ var world = new World()
 var player = new Player({
   position: {x: 0, y: 0},
   rotation: 0,
-  size: {x: 10, y: 10},
+  size: {x: 2, y: 2},
   velocity: {x: 0, y: 0},
-  speed: 2,
+  speed: .5,
   friction: 0.9,
   color: '#EB7576'
 });
 
 var camera = new Camera({
-  position: {x: 0, y: 0, z: 10},
+  position: {x: 0, y: 0, z: .1},
   rotation: 0,
-  speed: 1,
+  speed: .5,
   velocity: 0,
   friction: 0.9,
   velocity: { x: 0, y: 0, z: 0},

--- a/game.js
+++ b/game.js
@@ -16,23 +16,23 @@ var mouse = new Mouse(game)
 var world = new World()
 
 var player = new Player({
-  position: { x: 0, y: 0 },
+  position: {x: 0, y: 0},
   orientation: 0,
-  size: { x: 2, y: 2 },
-  velocity: { x: 0, y: 0 },
-  speed: .7,
+  size: {x: 10, y: 10},
+  velocity: {x: 0, y: 0},
+  speed: 2,
   friction: 0.9,
   color: '#EB7576'
 });
 
 var camera = new Camera({
-  position: {x: 0, y:0, z: 80},
+  position: {x: 0, y: 0, z: 10},
   orientation: 0,
-  speed: 2,
+  speed: 1,
   velocity: 0,
   friction: 0.9,
   velocity: { x: 0, y: 0, z: 0},
-  yoked: true
+  yoked: false
 })
 
 player.addTo(game)

--- a/game.js
+++ b/game.js
@@ -32,7 +32,7 @@ var camera = new Camera({
   velocity: 0,
   friction: 0.9,
   velocity: { x: 0, y: 0, z: 0},
-  yoked: true
+  yoked: false
 })
 
 player.addTo(game)
@@ -70,7 +70,7 @@ game.on('draw', function(context){
   if (camera.yoked){
     camera.position.x = player.position.x 
     camera.position.y = player.position.y
-    camera.orientation = player.orientation
+    camera.rotation = player.rotation
   }
   world.render(context, camera)
   player.render(context, camera)

--- a/geometry.js
+++ b/geometry.js
@@ -1,3 +1,5 @@
+var _ = require('lodash')
+
 function Geometry(props, children) {
 
   this.init(props || {})

--- a/geometry.js
+++ b/geometry.js
@@ -1,0 +1,54 @@
+function Geometry(props, children) {
+
+  this.init(props || {})
+  this.children = children || []
+  this.update()
+
+}
+
+Geometry.prototype.update = function(context) {
+
+  var self = this
+
+  self.points = self.transform.apply(self.points)
+
+  if (self.parent) self.points = self.parent.transform.apply(self.points)
+
+  if (self.children.length) {
+    _.forEach(self.children, function(child) {
+      child.parent = self
+      child.update()
+    })
+  }
+
+}
+
+Geometry.prototype.draw = function(context, points) {
+
+  context.beginPath()
+  _.forEach(points, function(point) {
+    context.lineTo(point[0], point[1])
+  })
+  context.closePath()
+  context.fillStyle = this.props.fill
+  context.strokeStyle = this.props.stroke
+  context.fill()
+  context.stroke()
+
+}
+
+Geometry.prototype.render = function(context, camera) {
+
+  var points = this.points
+  points = camera.transform.apply(points)
+  this.draw(context, points)
+
+  if (this.children) {
+    this.children.forEach(function (child) {
+      child.render(context, camera)
+    })
+  }
+
+}
+
+module.exports = Geometry

--- a/geometry.js
+++ b/geometry.js
@@ -38,9 +38,12 @@ Geometry.prototype.draw = function(context, points) {
 }
 
 Geometry.prototype.render = function(context, camera) {
-
   var points = this.points
-  points = camera.transform.apply(points)
+
+  points = camera.transform.invert(points)
+  points = points.map(function (point) {
+    return [point[0] + camera.game.width/2, point[1] + camera.game.height/2]
+  })
   this.draw(context, points)
 
   if (this.children) {

--- a/path.js
+++ b/path.js
@@ -3,15 +3,16 @@ _ = require('lodash')
 
 module.exports = Path
 
-function Path(options){
-  var options = options || {}
-  this.position = 0
+function Path(props){
+  if (!props) props = {}
+  this.parent = props.parent
   this.type = 'path'
-  this.width = options.width || 0.2
-  this.color = options.color || "#DFE0E2"
+  this.width = props.width || 0.2
+  this.color = props.color || "#DFE0E2"
+  this.init()
 }
 
-Path.prototype.points = function() {
+Path.prototype.init = function() {
   var self = this
   var bottom = Math.sqrt(3)/2
   var points = [
@@ -20,11 +21,13 @@ Path.prototype.points = function() {
     [self.width/2, bottom],
     [self.width/2, 0]
   ]
-  return points
+  if (this.parent) points = this.parent.transform.apply(points)
+  this.points = points
 }
 
-Path.prototype.render = function(context, transform) {
-  var points = transform.apply(this.points())
+Path.prototype.render = function(context, camera) {
+  var points = this.points
+  points = camera.transform.apply(points)
   context.beginPath()
   _.forEach(points, function(point) {
     context.lineTo(point[0], point[1])

--- a/path.js
+++ b/path.js
@@ -3,7 +3,7 @@ _ = require('lodash')
 
 module.exports = Path
 
-function Path(props){
+function Path (props) {
   if (!props) props = {}
   this.parent = props.parent
   this.type = 'path'

--- a/path.js
+++ b/path.js
@@ -1,46 +1,28 @@
-aabb = require('aabb-2d')
-_ = require('lodash')
+var inherits = require('inherits')
+var Geometry = require('./geometry.js')
+var Transform = require('./transform.js')
 
 module.exports = Path
+inherits(Path, Geometry)
 
-function Path (props) {
-  if (!props) props = {}
-  this.parent = props.parent
-  this.type = 'path'
-  this.width = props.width || 0.2
-  this.color = props.color || "#DFE0E2"
-  this.init()
+function Path(props, children) {
+  Geometry.call(this, props, children)
 }
 
-Path.prototype.init = function() {
-  var self = this
-  var bottom = Math.sqrt(3)/2
+Path.prototype.init = function(props) {
+  
+  this.props = {
+    fill: props.fill || '#DFE0E2',
+    stroke: props.stroke || '#DFE0E2'
+  } 
+
+  this.transform = new Transform()
+
   var points = [
-    [-self.width/2, 0],
-    [-self.width/2, bottom],
-    [self.width/2, bottom],
-    [self.width/2, 0]
+    [-0.2/2, 0],
+    [-0.2/2, Math.sqrt(3)/2],
+    [0.2/2, Math.sqrt(3)/2],
+    [0.2/2, 0]
   ]
-  if (this.parent) points = this.parent.transform.apply(points)
   this.points = points
-}
-
-Path.prototype.draw = function(context, points) {
-  context.beginPath()
-  _.forEach(points, function(point) {
-    context.lineTo(point[0], point[1])
-  })
-  context.closePath()
-  context.fillStyle = this.color
-  context.fill()
-}
-
-Path.prototype.render = function(context, camera) {
-  var points = this.points
-  points = camera.transform.invert(points)
-  // translate
-  points = points.map(function(point) {
-    return [point[0] + this.game.width/2, point[1] + this.game.height/2]
-  })
-  this.draw(context, points)
 }

--- a/path.js
+++ b/path.js
@@ -25,9 +25,7 @@ Path.prototype.init = function() {
   this.points = points
 }
 
-Path.prototype.render = function(context, camera) {
-  var points = this.points
-  points = camera.transform.apply(points)
+Path.prototype.draw = function(context, points) {
   context.beginPath()
   _.forEach(points, function(point) {
     context.lineTo(point[0], point[1])
@@ -35,4 +33,10 @@ Path.prototype.render = function(context, camera) {
   context.closePath()
   context.fillStyle = this.color
   context.fill()
+}
+
+Path.prototype.render = function(context, camera) {
+  var points = this.points
+  points = camera.transform.apply(points)
+  this.draw(context, points)
 }

--- a/path.js
+++ b/path.js
@@ -11,25 +11,22 @@ function Path(options){
   this.color = options.color || "#DFE0E2"
 }
 
-Path.prototype.border = function(transform) {
+Path.prototype.points = function() {
   var self = this
-  var bottom = transform.scale * Math.sqrt(3)/2
+  var bottom = Math.sqrt(3)/2
   var points = [
-    [-self.width/2 * transform.scale, 0],
-    [-self.width/2 * transform.scale, bottom],
-    [self.width/2 * transform.scale, bottom],
-    [self.width/2 * transform.scale, 0]
+    [-self.width/2, 0],
+    [-self.width/2, bottom],
+    [self.width/2, bottom],
+    [self.width/2, 0]
   ]
-  points = math.multiply(points, transform.rotation)
-  return points.map(function(v) {
-    return math.add(v,[transform.position.x + game.width/2, transform.position.y + game.height/2])
-  })
+  return points
 }
 
 Path.prototype.render = function(context, transform) {
-  var border = this.border(transform)
+  var points = transform.apply(this.points())
   context.beginPath()
-  _.forEach(border, function(point) {
+  _.forEach(points, function(point) {
     context.lineTo(point[0], point[1])
   })
   context.closePath()

--- a/path.js
+++ b/path.js
@@ -37,6 +37,10 @@ Path.prototype.draw = function(context, points) {
 
 Path.prototype.render = function(context, camera) {
   var points = this.points
-  points = camera.transform.apply(points)
+  points = camera.transform.invert(points)
+  // translate
+  points = points.map(function(point) {
+    return [point[0] + this.game.width/2, point[1] + this.game.height/2]
+  })
   this.draw(context, points)
 }

--- a/player.js
+++ b/player.js
@@ -5,8 +5,6 @@ var Entity = require('crtrdg-entity');
 module.exports = Player;
 inherits(Player, Entity);
 
-// add the camera position, subtract the center, rotate, add center
-
 function Player(options){
   this.position = { 
     x: options.position.x, 
@@ -18,7 +16,7 @@ function Player(options){
     y: options.size.y
   };
 
-  this.orientation = options.orientation
+  this.rotation = options.rotation
 
   this.velocity = {
     x: options.velocity.x,
@@ -37,7 +35,7 @@ function Player(options){
 }
 
 Player.prototype.move = function(velocity){
-  var angle = this.orientation * Math.PI / 180
+  var angle = this.rotation * Math.PI / 180
   this.position.x += velocity.x*Math.cos(angle)-velocity.y*Math.sin(angle);
   this.position.y += velocity.x*Math.sin(angle)+velocity.y*Math.cos(angle);
 //  this.position.x += velocity.x;
@@ -80,20 +78,20 @@ Player.prototype.keyboardInput = function(keyboard){
   }
 
   if ('A' in keyboard.keysDown){
-    this.orientation -= this.speed*1.9
-    if (this.orientation < 0) this.orientation = 360
+    this.rotation -= this.speed*1.9
+    if (this.rotation < 0) this.rotation = 360
   }
 
   if ('D' in keyboard.keysDown){
-    this.orientation += this.speed*1.9
-    if (this.orientation > 360) this.orientation = 0
+    this.rotation += this.speed*1.9
+    if (this.rotation > 360) this.rotation = 0
   }
 }
 
 Player.prototype.render = function(context, camera) {
 
   var self = this
-  var angle = camera.orientation * Math.PI / 180
+  var angle = camera.rotation * Math.PI / 180
   var scale = 0.1 * camera.position.z
   var position = [self.position.x*scale, self.position.y*scale]
   var rotation = [[Math.cos(angle), -Math.sin(angle)], [Math.sin(angle), Math.cos(angle)]] 
@@ -108,7 +106,7 @@ Player.prototype.render = function(context, camera) {
 //  var originX = position[0] - camera.position.x+game.width/2
 //  var originY = position[1] - camera.position.y+game.height/2
   
-  angle = self.orientation * Math.PI / 180 - angle
+  angle = self.rotation * Math.PI / 180 - angle
 
   context.lineWidth = 3
 

--- a/player.js
+++ b/player.js
@@ -1,6 +1,8 @@
-var inherits = require('inherits');
-var aabb = require('aabb-2d');
-var Entity = require('crtrdg-entity');
+var inherits = require('inherits')
+var aabb = require('aabb-2d')
+var math = require('mathjs')
+var Entity = require('crtrdg-entity')
+
 
 module.exports = Player;
 inherits(Player, Entity);

--- a/player.js
+++ b/player.js
@@ -94,16 +94,17 @@ Player.prototype.render = function(context, camera) {
 
   var self = this
   var angle = camera.rotation * Math.PI / 180
-  var scale = 0.1 * camera.position.z
-  var position = [self.position.x*scale, self.position.y*scale]
+  var scale = 1/camera.transform.scale
+//  var position = [self.position.x*scale, self.position.y*scale]
+  var position = [self.position.x, self.position.y]
   var rotation = [[Math.cos(angle), -Math.sin(angle)], [Math.sin(angle), Math.cos(angle)]] 
 
   position[0] = position[0] - camera.position.x
   position[1] = position[1] - camera.position.y
   var position = math.multiply(position, rotation)
 
-  var originX = position[0] + game.width/2
-  var originY = position[1] + game.height/2
+  var originX = scale*position[0] + game.width/2
+  var originY = scale*position[1] + game.height/2
 
 //  var originX = position[0] - camera.position.x+game.width/2
 //  var originY = position[1] - camera.position.y+game.height/2

--- a/tile.js
+++ b/tile.js
@@ -1,28 +1,21 @@
-_ = require('lodash')
-Path = require('./path.js')
-Center = require('./center.js')
-Transform = require('./transform.js')
+var _ = require('lodash')
+var inherits = require('inherits')
+var Geometry = require('./geometry.js')
+var Transform = require('./transform.js')
 
 module.exports = Tile
+inherits(Tile, Geometry);
 
-function Tile(props) {
-  if (!props) props = {}
-  
-  this.coordinate = props.coordinate
-  this.color = props.color || '#A5A5A5'
-  this.parent = props.parent
-
-  this.init(props)
-  this.update()
-
-  this.children = [
-    new Path({parent: this}), 
-    new Center({parent: this})
-  ]
-
+function Tile(props, children) {
+  Geometry.call(this, props, children)
 }
 
 Tile.prototype.init = function(props) {
+  this.props = {
+    fill: props.fill || '#A5A5A5',
+    stroke: props.stroke || '#A5A5A5'
+  } 
+
   var scale = (props.scale || 50)
   var x = scale * 3/2 * props.coordinate.r
   var y = scale * Math.sqrt(3) * (props.coordinate.q + props.coordinate.r/2)
@@ -34,31 +27,4 @@ Tile.prototype.init = function(props) {
     return [dx, dy]
   })
   this.points = points
-}
-
-Tile.prototype.update = function() {
-  var self = this
-  self.points = self.transform.apply(self.points)
-  if (self.parent) self.points = self.parent.transform.apply(self.points)
-}
-
-Tile.prototype.draw = function(context, points) {
-  context.beginPath()
-  _.forEach(points, function(point) {
-    context.lineTo(point[0], point[1])
-  })
-  context.closePath()
-  context.fillStyle = this.color
-  context.strokeStyle = this.color
-  context.fill()
-  context.stroke()
-}
-
-Tile.prototype.render = function(context, camera) {
-  var points = this.points
-  points = camera.transform.apply(points)
-  this.draw(context, points)
-  this.children.forEach(function (child) {
-    child.render(context, camera)
-  })
 }

--- a/tile.js
+++ b/tile.js
@@ -6,47 +6,37 @@ Transform = require('./transform.js')
 
 module.exports = Tile
 
-function Tile(options){
-  this.position = { 
-    r: options.position.r, 
-    q: options.position.q
-  }
-  this.paths = options.paths || [new Path({position: 0}), new Path({position: 1})]
-  this.center = new Center()
-  this.size = options.size || 50
-  this.color = options.color || '#A5A5A5'
+function Tile(props){
+  if (!props) props = {}
+
+  var scale = (props.size || 50)
+  var x = scale * 3/2 * props.position.r
+  var y = scale * Math.sqrt(3) * (props.position.q + props.position.r/2)
+  
+  this.position = props.position
+  this.size = scale
+  this.color = props.color || '#A5A5A5'
+  this.parent = props.parent
+  this.transform = new Transform({position: {x: x, y: y}, scale: scale})
+  this.children = [
+    new Path({parent: this}), 
+    new Center({parent: this})
+  ]
+  this.init()
 }
 
-Tile.prototype.transform = function(camera) {
-
-  var scale = this.size * 0.1 * camera.position.z
-  var x = scale * 3/2 * this.position.r
-  var y = scale * Math.sqrt(3) * (this.position.q + this.position.r/2)
-  var angle = camera.orientation * Math.PI / 180
-  var rotation = [[Math.cos(angle), -Math.sin(angle)], [Math.sin(angle), Math.cos(angle)]] 
-  x = x - camera.position.x
-  y = y - camera.position.y
-  var position = math.multiply([x, y], rotation)
-  x = position[0]
-  y = position[1]
-  //x = position[0] - camera.position.x
-  //y = position[1] - camera.position.y
-  return new Transform({position: {x: x, y: y}, scale: scale, rotation: rotation})
-
-}
-
-Tile.prototype.points = function() {
+Tile.prototype.init = function() {
   var points = _.range(7).map(function(i) {
     var dx = Math.cos(i * 2 * Math.PI / 6)
     var dy = Math.sin(i * 2 * Math.PI / 6)
     return [dx, dy]
   })
-  return points
+  points = this.transform.apply(points)
+  if (this.parent) points = this.parent.transform.apply(points)
+  this.points = points
 }
 
-Tile.prototype.draw = function(context, transform) {
-  var self = this
-  var points = transform.apply(self.points())
+Tile.prototype.draw = function(context, points) {
   context.beginPath()
   _.forEach(points, function(point) {
     context.lineTo(point[0], point[1])
@@ -59,13 +49,11 @@ Tile.prototype.draw = function(context, transform) {
 }
 
 Tile.prototype.render = function(context, camera) {
-
-  var transform = this.transform(camera)
-
-  this.draw(context, transform)
-  this.center.render(context, transform)
-  this.paths.forEach(function (path) {
-    path.render(context, transform)
+  var points = this.points
+  points = camera.transform.apply(points)
+  this.draw(context, points)
+  this.children.forEach(function (child) {
+    child.render(context, camera)
   })
 
 }

--- a/tile.js
+++ b/tile.js
@@ -1,5 +1,4 @@
 _ = require('lodash')
-math = require('mathjs')
 Path = require('./path.js')
 Center = require('./center.js')
 Transform = require('./transform.js')
@@ -9,12 +8,11 @@ module.exports = Tile
 function Tile(props){
   if (!props) props = {}
 
-  var scale = (props.size || 50)
-  var x = scale * 3/2 * props.position.r
-  var y = scale * Math.sqrt(3) * (props.position.q + props.position.r/2)
+  var scale = (props.scale || 50)
+  var x = scale * 3/2 * props.coordinate.r
+  var y = scale * Math.sqrt(3) * (props.coordinate.q + props.coordinate.r/2)
   
-  this.position = props.position
-  this.size = scale
+  this.coordinate = props.coordinate
   this.color = props.color || '#A5A5A5'
   this.parent = props.parent
   this.transform = new Transform({position: {x: x, y: y}, scale: scale})

--- a/tile.js
+++ b/tile.js
@@ -56,7 +56,11 @@ Tile.prototype.draw = function(context, points) {
 
 Tile.prototype.render = function(context, camera) {
   var points = this.points
-  points = camera.transform.apply(points)
+  points = camera.transform.invert(points)
+  // translate
+  points = points.map(function(point) {
+    return [point[0] + this.game.width/2, point[1] +this.game.height/2]
+  })
   this.draw(context, points)
   this.children.forEach(function (child) {
     child.render(context, camera)

--- a/tile.js
+++ b/tile.js
@@ -2,6 +2,7 @@ _ = require('lodash')
 math = require('mathjs')
 Path = require('./path.js')
 Center = require('./center.js')
+Transform = require('./transform.js')
 
 module.exports = Tile
 
@@ -30,28 +31,24 @@ Tile.prototype.transform = function(camera) {
   y = position[1]
   //x = position[0] - camera.position.x
   //y = position[1] - camera.position.y
-  return {position: {x: x, y: y}, scale: scale, rotation: rotation}
+  return new Transform({position: {x: x, y: y}, scale: scale, rotation: rotation})
 
 }
 
-Tile.prototype.border = function(transform) {
-
+Tile.prototype.points = function() {
   var points = _.range(7).map(function(i) {
-    var dx = transform.scale * Math.cos(i * 2 * Math.PI / 6)
-    var dy = transform.scale * Math.sin(i * 2 * Math.PI / 6)
+    var dx = Math.cos(i * 2 * Math.PI / 6)
+    var dy = Math.sin(i * 2 * Math.PI / 6)
     return [dx, dy]
   })
-  points = math.multiply(points, transform.rotation)
-  return points.map(function(v) {
-    return math.add(v,[transform.position.x + game.width/2, transform.position.y + game.height/2])
-  })
+  return points
 }
 
 Tile.prototype.draw = function(context, transform) {
-
-  var border = this.border(transform)
+  var self = this
+  var points = transform.apply(self.points())
   context.beginPath()
-  _.forEach(border, function(point) {
+  _.forEach(points, function(point) {
     context.lineTo(point[0], point[1])
   })
   context.closePath()
@@ -59,7 +56,6 @@ Tile.prototype.draw = function(context, transform) {
   context.strokeStyle = this.color
   context.fill()
   context.stroke()
-
 }
 
 Tile.prototype.render = function(context, camera) {
@@ -67,9 +63,7 @@ Tile.prototype.render = function(context, camera) {
   var transform = this.transform(camera)
 
   this.draw(context, transform)
-
   this.center.render(context, transform)
-
   this.paths.forEach(function (path) {
     path.render(context, transform)
   })

--- a/tile.js
+++ b/tile.js
@@ -5,33 +5,41 @@ Transform = require('./transform.js')
 
 module.exports = Tile
 
-function Tile(props){
+function Tile(props) {
   if (!props) props = {}
-
-  var scale = (props.scale || 50)
-  var x = scale * 3/2 * props.coordinate.r
-  var y = scale * Math.sqrt(3) * (props.coordinate.q + props.coordinate.r/2)
   
   this.coordinate = props.coordinate
   this.color = props.color || '#A5A5A5'
   this.parent = props.parent
-  this.transform = new Transform({position: {x: x, y: y}, scale: scale})
+
+  this.init(props)
+  this.update()
+
   this.children = [
     new Path({parent: this}), 
     new Center({parent: this})
   ]
-  this.init()
+
 }
 
-Tile.prototype.init = function() {
+Tile.prototype.init = function(props) {
+  var scale = (props.scale || 50)
+  var x = scale * 3/2 * props.coordinate.r
+  var y = scale * Math.sqrt(3) * (props.coordinate.q + props.coordinate.r/2)
+  this.transform = new Transform({position: {x: x, y: y}, scale: scale})
+  
   var points = _.range(7).map(function(i) {
     var dx = Math.cos(i * 2 * Math.PI / 6)
     var dy = Math.sin(i * 2 * Math.PI / 6)
     return [dx, dy]
   })
-  points = this.transform.apply(points)
-  if (this.parent) points = this.parent.transform.apply(points)
   this.points = points
+}
+
+Tile.prototype.update = function() {
+  var self = this
+  self.points = self.transform.apply(self.points)
+  if (self.parent) self.points = self.parent.transform.apply(self.points)
 }
 
 Tile.prototype.draw = function(context, points) {
@@ -53,5 +61,4 @@ Tile.prototype.render = function(context, camera) {
   this.children.forEach(function (child) {
     child.render(context, camera)
   })
-
 }

--- a/transform.js
+++ b/transform.js
@@ -1,12 +1,9 @@
-math = require('mathjs')
-
 module.exports = Transform
 
 function Transform(parameters){
   this.position = parameters.position || {x: 0, y: 0}
   this.scale = parameters.scale || 1
-  var theta = (parameters.rotation * Math.PI / 180) || 0
-  this.rotation = [[Math.cos(theta), -Math.sin(theta)], [Math.sin(theta), Math.cos(theta)]] 
+  this.rotation = rotmat((parameters.rotation * Math.PI / 180) || 0)
   return this
 }
 
@@ -17,9 +14,15 @@ Transform.prototype.apply = function(points) {
   points = points.map( function(point) {
     return [point[0] * self.scale, point[1] * self.scale]
   })
+
   // rotate
-  points = math.multiply(points, self.rotation)
-  
+  points = points.map( function(point) {
+    return [
+      point[0] * self.rotation[0][0] + point[1] * self.rotation[0][1],
+      point[0] * self.rotation[1][0] + point[1] * self.rotation[1][1],
+    ]
+  })
+
   // translate
   points = points.map(function(point) {
     return [point[0] + self.position.x, point[1] + self.position.y]
@@ -30,8 +33,9 @@ Transform.prototype.apply = function(points) {
 Transform.prototype.update = function(parameters) {
   if (parameters.position) this.position = parameters.position
   if (parameters.scale) this.scale = parameters.scale
-  if (parameters.rotation) {
-    var theta = parameters.rotation * Math.PI / 180
-    this.rotation = [[Math.cos(theta), -Math.sin(theta)], [Math.sin(theta), Math.cos(theta)]] 
-  }
+  if (parameters.rotation) this.rotation = rotmat(parameters.rotation * Math.PI / 180)
+}
+
+rotmat = function(theta) {
+  return [[Math.cos(theta), -Math.sin(theta)], [Math.sin(theta), Math.cos(theta)]] 
 }

--- a/transform.js
+++ b/transform.js
@@ -1,0 +1,26 @@
+math = require('mathjs')
+
+module.exports = Transform
+
+function Transform(parameters){
+  this.position = parameters.position
+  this.scale = parameters.scale
+  this.rotation = parameters.rotation
+  return this
+}
+
+Transform.prototype.apply = function(points) {
+  var self = this
+  // rescale
+  points = points.map( function(point) {
+    return [point[0] * self.scale, point[1] * self.scale]
+  })
+  // rotate
+  points = math.multiply(points, self.rotation)
+  // translate
+  points = points.map(function(point) {
+    return [point[0] + self.position.x + game.width/2, point[1] + self.position.y + game.height/2]
+  })
+
+  return points
+}

--- a/transform.js
+++ b/transform.js
@@ -30,6 +30,31 @@ Transform.prototype.apply = function(points) {
   return points
 }
 
+Transform.prototype.invert = function(points) {
+  var self = this
+
+  // translate
+  points = points.map(function(point) {
+    return [point[0] - self.position.x, point[1] - self.position.y]
+  })
+
+  // rotate
+  points = points.map( function(point) {
+    return [
+      point[0] * self.rotation[0][0] - point[1] * self.rotation[0][1],
+      - point[0] * self.rotation[1][0] + point[1] * self.rotation[1][1],
+    ]
+  })
+
+  // rescale
+  points = points.map( function(point) {
+    return [point[0] / self.scale, point[1] / self.scale]
+  })
+
+  return points
+}
+
+
 Transform.prototype.update = function(parameters) {
   if (parameters.position) this.position = parameters.position
   if (parameters.scale) this.scale = parameters.scale

--- a/transform.js
+++ b/transform.js
@@ -3,24 +3,35 @@ math = require('mathjs')
 module.exports = Transform
 
 function Transform(parameters){
-  this.position = parameters.position
-  this.scale = parameters.scale
-  this.rotation = parameters.rotation
+  this.position = parameters.position || {x: 0, y: 0}
+  this.scale = parameters.scale || 1
+  var theta = (parameters.rotation * Math.PI / 180) || 0
+  this.rotation = [[Math.cos(theta), -Math.sin(theta)], [Math.sin(theta), Math.cos(theta)]] 
   return this
 }
 
 Transform.prototype.apply = function(points) {
   var self = this
+
   // rescale
   points = points.map( function(point) {
     return [point[0] * self.scale, point[1] * self.scale]
   })
   // rotate
   points = math.multiply(points, self.rotation)
+  
   // translate
   points = points.map(function(point) {
-    return [point[0] + self.position.x + game.width/2, point[1] + self.position.y + game.height/2]
+    return [point[0] + self.position.x, point[1] + self.position.y]
   })
-
   return points
+}
+
+Transform.prototype.update = function(parameters) {
+  if (parameters.position) this.position = parameters.position
+  if (parameters.scale) this.scale = parameters.scale
+  if (parameters.rotation) {
+    var theta = parameters.rotation * Math.PI / 180
+    this.rotation = [[Math.cos(theta), -Math.sin(theta)], [Math.sin(theta), Math.cos(theta)]] 
+  }
 }

--- a/transform.js
+++ b/transform.js
@@ -1,6 +1,7 @@
 module.exports = Transform
 
 function Transform(parameters){
+  parameters = parameters || {}
   this.position = parameters.position || {x: 0, y: 0}
   this.scale = parameters.scale || 1
   this.rotation = rotmat((parameters.rotation * Math.PI / 180) || 0)

--- a/world.js
+++ b/world.js
@@ -1,17 +1,20 @@
-var tile = require('./tile.js')
+var Tile = require('./tile.js')
+var Path = require('./path.js')
+var Center = require('./center.js')
 
 module.exports = World
 
 function World() {
   this.tiles = [
-    new tile({coordinate: { r: -1, q: 0}}), 
-    new tile({coordinate: { r: 0, q: 0}}), 
-    new tile({coordinate: { r: 0, q: 1}}),
-    new tile({coordinate: { r: -1, q: 1}}),
-    new tile({coordinate: { r: 1, q: -1}}),
-    new tile({coordinate: { r: 1, q: 0}}),
-    new tile({coordinate: { r: 0, q: -1}})
+    new Tile({coordinate: {r: -1, q: 0}}, [new Center()]), 
+    new Tile({coordinate: {r: 0, q: 0}}, [new Center()]), 
+    new Tile({coordinate: {r: 0, q: 1}}, [new Center()]),
+    new Tile({coordinate: {r: -1, q: 1}}, [new Center()]),
+    new Tile({coordinate: {r: 1, q: -1}}, [new Center()]),
+    new Tile({coordinate: {r: 1, q: 0}}, [new Center()]),
+    new Tile({coordinate: {r: 0, q: -1}}, [new Center()])
   ]
+  console.log(this.tiles[0])
 }
 
 World.prototype.render = function(context, camera) {

--- a/world.js
+++ b/world.js
@@ -4,13 +4,13 @@ module.exports = World
 
 function World() {
   this.tiles = [
-    new tile({position: { r: -1, q: 0}}), 
-    new tile({position: { r: 0, q: 0}}), 
-    new tile({position: { r: 0, q: 1}}),
-    new tile({position: { r: -1, q: 1}}),
-    new tile({position: { r: 1, q: -1}}),
-    new tile({position: { r: 1, q: 0}}),
-    new tile({position: { r: 0, q: -1}})
+    new tile({coordinate: { r: -1, q: 0}}), 
+    new tile({coordinate: { r: 0, q: 0}}), 
+    new tile({coordinate: { r: 0, q: 1}}),
+    new tile({coordinate: { r: -1, q: 1}}),
+    new tile({coordinate: { r: 1, q: -1}}),
+    new tile({coordinate: { r: 1, q: 0}}),
+    new tile({coordinate: { r: 0, q: -1}})
   ]
 }
 

--- a/world.js
+++ b/world.js
@@ -6,13 +6,13 @@ module.exports = World
 
 function World() {
   this.tiles = [
-    new Tile({coordinate: {r: -1, q: 0}}, [new Center()]), 
-    new Tile({coordinate: {r: 0, q: 0}}, [new Center()]), 
-    new Tile({coordinate: {r: 0, q: 1}}, [new Center()]),
-    new Tile({coordinate: {r: -1, q: 1}}, [new Center()]),
-    new Tile({coordinate: {r: 1, q: -1}}, [new Center()]),
-    new Tile({coordinate: {r: 1, q: 0}}, [new Center()]),
-    new Tile({coordinate: {r: 0, q: -1}}, [new Center()])
+    new Tile({coordinate: {r: -1, q: 0}}, [new Center(), new Path()]), 
+    new Tile({coordinate: {r: 0, q: 0}}, [new Center(), new Path()]), 
+    new Tile({coordinate: {r: 0, q: 1}}, [new Center(), new Path()]),
+    new Tile({coordinate: {r: -1, q: 1}}, [new Center(), new Path()]),
+    new Tile({coordinate: {r: 1, q: -1}}, [new Center(), new Path()]),
+    new Tile({coordinate: {r: 1, q: 0}}, [new Center(), new Path()]),
+    new Tile({coordinate: {r: 0, q: -1}}, [new Center(), new Path()])
   ]
   console.log(this.tiles[0])
 }


### PR DESCRIPTION
This PR refactors the geometry rendering by breaking off two modular pieces -- transforms, and geometry, both of which we can probably make into proper `crtrdg` modules.

A transform has a `position`, `scale`, and `rotation`, and can be used to `apply` or `invert` a set of points.

A geometry has methods for `draw`, `render`, and `update`, and is meant to be extended by writing an initialization function.
