### PR TITLE
Bezier curves

### DIFF
--- a/geo/circle.js
+++ b/geo/circle.js
@@ -7,14 +7,15 @@ module.exports = function (opts) {
     props: {
       fill: opts.fill || '#DFE0E2',
       stroke: opts.stroke || '#DFE0E2',
-      type: 'circle'
+      type: 'bezier'
     },
 
-    shape: {
-      position: [0, 0],
-      scale: 1,
-      angle: 0
-    },
+    points: [
+      [0, -1], [0.55, -1], [1, -0.55],
+      [1, 0], [1, 0.55], [0.55, 1],
+      [0, 1], [-0.55, 1], [-1, 0.55],
+      [-1, 0], [-1, -0.55], [-0.55, -1]
+    ],
 
     transform: {
       scale: opts.scale

--- a/geo/hex.js
+++ b/geo/hex.js
@@ -11,7 +11,7 @@ module.exports = function (opts) {
       type: 'polygon'
     },
 
-    shape: _.range(7).map(function(i) {
+    points: _.range(7).map(function(i) {
       var dx =  Math.cos(i * 2 * Math.PI / 6)
       var dy =  Math.sin(i * 2 * Math.PI / 6)
       return [dx, dy]

--- a/geo/path.js
+++ b/geo/path.js
@@ -11,17 +11,17 @@ module.exports = function (opts) {
       type: 'polygon'
     },
 
-    transform: {
-      scale: opts.scale || 1,
-      angle: opts.angle || 0
-    },
-
-    shape: [
+    points: [
       [-0.25/2, 0],
       [-0.25/2, Math.sqrt(3)/2],
       [0.25/2, Math.sqrt(3)/2],
       [0.25/2, 0]
     ],
+
+    transform: {
+      scale: opts.scale || 1,
+      angle: opts.angle || 0
+    },
 
     children: opts.children
   })

--- a/geo/tile.js
+++ b/geo/tile.js
@@ -11,6 +11,12 @@ module.exports = function (opts) {
       type: 'polygon'
     },
 
+    points: _.range(7).map(function (i) {
+      var dx = Math.cos(i * 2 * Math.PI / 6)
+      var dy = Math.sin(i * 2 * Math.PI / 6)
+      return [dx, dy]
+    }),
+
     transform: {
       position: [
         opts.scale * 3/2 * opts.position[0], 
@@ -18,12 +24,6 @@ module.exports = function (opts) {
       ],
       scale: opts.scale
     },
-
-    shape: _.range(7).map(function (i) {
-      var dx = Math.cos(i * 2 * Math.PI / 6)
-      var dy = Math.sin(i * 2 * Math.PI / 6)
-      return [dx, dy]
-    }),
 
     children: opts.children
   })

--- a/transform.js
+++ b/transform.js
@@ -10,7 +10,7 @@ module.exports = function(opts) {
     rotation =  [[Math.cos(angle), -Math.sin(angle)], [Math.sin(angle), Math.cos(angle)]]
   }
 
-  var fwdpoints = function (points) {
+  var apply = function (points) {
     points = points.map( function(xy) {
       return [xy[0] * scale, xy[1] * scale]
     })
@@ -26,7 +26,7 @@ module.exports = function(opts) {
     return points
   }
 
-  var invpoints = function (points) {
+  var invert = function (points) {
     points = points.map(function (xy) {
       return [xy[0] - position[0], xy[1] - position[1]]
     })
@@ -40,38 +40,6 @@ module.exports = function(opts) {
       return [xy[0] / scale, xy[1] / scale]
     })
     return points
-  }
-
-  var fwdparams = function (shape) {
-    shape = {
-      position: fwdpoints([shape.position])[0],
-      angle: shape.angle + angle,
-      scale: shape.scale * scale
-    }
-    return shape
-  }
-
-  var invparams = function (shape) {
-    shape = {
-      position: invpoints([shape.position])[0],
-      angle: shape.angle - angle,
-      scale: shape.scale / scale
-    }
-    return shape
-  }
-
-  var apply = function (obj) {
-    if (obj instanceof Array) return fwdpoints(obj)
-    return fwdparams(obj)
-  }
-
-  var invert = function (obj) {
-    if (obj instanceof Array) return invpoints(obj)
-    return invparams(obj)
-  }
-
-  var position = function () {
-    return position
   }
 
   set(opts)


### PR DESCRIPTION
Use bezier curves for circles / ellipses instead of the canvas built-in methods like `arc` and `ellipse`. This allows us to greatly simplify / generalize the functions related to spatial transforms, because they all just act on points.
