### PR TITLE
Basic collision

### DIFF
--- a/camera.js
+++ b/camera.js
@@ -18,13 +18,12 @@ function Camera(opts){
   this.movement = new Movement({
     speed: opts.speed,
     friction: opts.friction,
-    keymap: {position: [['J','L'],['K','I']], angle: ['U','O'], scale: [',','.']}
+    keymap: {position: [['L','J'],['K','I']], angle: ['O','U'], scale: [',','.']}
   })
 }
 
 Camera.prototype.move = function(keyboard) {
   var self = this
-  console.log(keyboard.keysDown)
-  self.movement.update(keyboard.keysDown)
-  self.movement.apply(self.transform)
+  var delta = self.movement.compute(keyboard.keysDown, self.transform.angle())
+  self.transform.compose(delta)
 }

--- a/camera.js
+++ b/camera.js
@@ -1,76 +1,29 @@
 var inherits = require('inherits');
 var aabb = require('aabb-2d');
-var Entity = require('crtrdg-entity');
 var transform = require('./transform.js')
+var Movement = require('./movement.js')
+var Entity = require('crtrdg-entity');
 
 module.exports = Camera;
 inherits(Camera, Entity);
 
 function Camera(opts){
   var self = this
-  this.speed = opts.speed
-  this.friction = opts.friction
-  this.velocity = opts.velocity
   this.yoked = opts.yoked
   this.transform = transform({
     position: opts.position, 
     scale: opts.scale,
     angle: opts.angle
   })
+  this.movement = new Movement({
+    speed: opts.speed,
+    friction: opts.friction ,
+    keymap: ['J','L','I','K','U','O',',','.']
+  })
 }
 
-Camera.prototype.move = function(velocity) {
+Camera.prototype.move = function(keyboard) {
   var self = this
-
-  var rad = self.transform.angle() * Math.PI / 180
-  var delta = {}
-  delta.position = [
-    velocity.position[0] * Math.cos(rad) - velocity.position[1] * Math.sin(rad),
-    velocity.position[0] * Math.sin(rad) + velocity.position[1] * Math.cos(rad)
-  ]
-  delta.angle = velocity.angle
-  delta.scale = velocity.scale
-
-  self.transform.update(delta)
-}
-
-Camera.prototype.keyboardInput = function(keyboard){
-  if ('J' in keyboard.keysDown){
-    this.velocity.position[0] = -this.speed
-  }
-
-  if ('L' in keyboard.keysDown){
-    this.velocity.position[0] = this.speed
-  }
-
-  if ('I' in keyboard.keysDown){
-    this.velocity.position[1] = -this.speed
-  }
-
-  if ('K' in keyboard.keysDown){
-    this.velocity.position[1] = this.speed
-  }
-
-  if ('O' in keyboard.keysDown){
-    this.velocity.angle = -this.speed
-  }
-
-  if ('U' in keyboard.keysDown){
-    this.velocity.angle = this.speed
-  }
-
-  if ('.' in keyboard.keysDown){
-    this.velocity.scale = -this.speed / 10
-  }
-
-  if (',' in keyboard.keysDown){
-    this.velocity.scale = this.speed / 10
-  }
-}
-
-Camera.prototype.dampen = function() {
-  this.velocity.position[0] *= this.friction
-  this.velocity.position[1] *= this.friction
-  this.velocity.angle *= this.friction
-  this.velocity.scale *= this.friction
+  self.movement.update(keyboard.keysDown)
+  self.movement.apply(self.transform)
 }

--- a/camera.js
+++ b/camera.js
@@ -17,13 +17,14 @@ function Camera(opts){
   })
   this.movement = new Movement({
     speed: opts.speed,
-    friction: opts.friction ,
-    keymap: ['J','L','I','K','U','O',',','.']
+    friction: opts.friction,
+    keymap: {position: [['J','L'],['K','I']], angle: ['U','O'], scale: [',','.']}
   })
 }
 
 Camera.prototype.move = function(keyboard) {
   var self = this
+  console.log(keyboard.keysDown)
   self.movement.update(keyboard.keysDown)
   self.movement.apply(self.transform)
 }

--- a/game.js
+++ b/game.js
@@ -75,6 +75,6 @@ game.on('draw', function(context) {
   player.draw(context, camera)
 })
 
-game.on('pause', function(){});
+game.on('pause', function(){})
 
-game.on('resume', function(){});
+game.on('resume', function(){})

--- a/game.js
+++ b/game.js
@@ -15,18 +15,15 @@ var keyboard = new Keyboard(game)
 var mouse = new Mouse(game)
 
 var player = new Player({
-  position: [0, 0],
-  angle: 0,
-  scale: 1.5,
-  velocity: {position: [0, 0], angle: 0},
-  speed: .4,
+  scale: 2,
+  speed: .1,
   friction: 0.9,
   color: '#EB7576'
 });
 
 var camera = new Camera({
   scale: 0.1,
-  speed: .5,
+  speed: .1,
   friction: 0.9,
   yoked: true
 })
@@ -38,9 +35,7 @@ camera.addTo(game)
 world.addTo(game)
 
 player.on('update', function(interval) {
-  this.keyboardInput(keyboard)
-  this.move(this.velocity, world)
-  this.dampen()
+  this.move(keyboard, world)
 });
 
 camera.on('update', function(interval) {

--- a/game.js
+++ b/game.js
@@ -13,7 +13,6 @@ var game = new Game({
 
 var keyboard = new Keyboard(game)
 var mouse = new Mouse(game)
-var world = new World()
 
 var player = new Player({
   position: [0, 0],
@@ -35,12 +34,15 @@ var camera = new Camera({
   yoked: true
 })
 
+var world = new World({player: player})
+
 player.addTo(game)
 camera.addTo(game)
+world.addTo(game)
 
 player.on('update', function(interval) {
   this.keyboardInput(keyboard)
-  this.move(this.velocity)
+  this.move(this.velocity, world)
   this.dampen()
 });
 
@@ -56,12 +58,17 @@ camera.on('update', function(interval) {
   this.dampen()
 })
 
+world.on('location', function(msg) {
+  console.log(msg)
+})
+
 game.on('draw-background', function(context) {
   context.fillStyle = '#F7F7F7'
   context.fillRect(0, 0, game.width, game.height)
 })
 
 game.on('update', function(interval){
+  // console.log(world.tiles[1].children[3].contains(player.position()))
   // get camera coordinates
   // draw world within those coordinates
   // need a function that renders a world given a camera (zoom, position, orientation)

--- a/game.js
+++ b/game.js
@@ -31,7 +31,7 @@ var camera = new Camera({
   velocity: {position: [0, 0], angle: 0},
   speed: .5,
   friction: 0.9,
-  yoked: true
+  yoked: false
 })
 
 var world = new World({player: player})

--- a/game.js
+++ b/game.js
@@ -25,13 +25,10 @@ var player = new Player({
 });
 
 var camera = new Camera({
-  position: [0, 0],
-  angle: 0,
-  scale: 0.6,
-  velocity: {position: [0, 0], angle: 0},
+  scale: 0.1,
   speed: .5,
   friction: 0.9,
-  yoked: false
+  yoked: true
 })
 
 var world = new World({player: player})
@@ -53,9 +50,7 @@ camera.on('update', function(interval) {
       angle: player.angle()
     })
   }
-  this.keyboardInput(keyboard)
-  this.move(this.velocity)
-  this.dampen()
+  this.move(keyboard)
 })
 
 world.on('location', function(msg) {

--- a/game.js
+++ b/game.js
@@ -19,7 +19,7 @@ var player = new Player({
   angle: 0,
   scale: 1.5,
   velocity: {position: [0, 0], angle: 0},
-  speed: .5,
+  speed: .4,
   friction: 0.9,
   color: '#EB7576'
 });
@@ -59,7 +59,7 @@ camera.on('update', function(interval) {
 })
 
 world.on('location', function(msg) {
-  console.log(msg)
+  //console.log(msg)
 })
 
 game.on('draw-background', function(context) {

--- a/geo/block.js
+++ b/geo/block.js
@@ -1,0 +1,32 @@
+var inherits = require('inherits')
+var Geometry = require('../geometry.js')
+
+module.exports = function (opts) {
+  opts = opts || {}
+  var width = opts.scale || 0.25
+  
+  return new Geometry({
+    props: {
+      fill: opts.fill || '#A5A5A5',
+      stroke: opts.stroke || '#A5A5A5',
+      type: 'polygon'
+    },
+
+    points: [
+      [-1/2, Math.sqrt(3)/2],
+      [-1/2, Math.sqrt(3)/2/width],
+      [1/2, Math.sqrt(3)/2/width],
+      [1/2, Math.sqrt(3)/2]
+    ],
+
+    transform: {
+      scale: width,
+      angle: opts.angle || 0
+    },
+
+    children: opts.children, 
+
+    obstacle: true
+  })
+
+}

--- a/geo/circle.js
+++ b/geo/circle.js
@@ -23,7 +23,9 @@ module.exports = function (opts) {
       angle: opts.angle || 0
     },
 
-    children: opts.children
+    children: opts.children,
+
+    trigger: true
   })
 
 } 

--- a/geo/tile.js
+++ b/geo/tile.js
@@ -5,10 +5,9 @@ var Geometry = require('../geometry.js')
 
 module.exports = function (opts) {
   opts = opts || {}
-  var wedges = [
-    wedge({angle: 0}), wedge({angle: 60}), wedge({angle: 120}), 
-    wedge({angle: 180}), wedge({angle: 240}), wedge({angle: 300})
-  ]
+  var wedges = _.range(6).map(function (i) {
+    return wedge({angle: i * 60})
+  })
   var blocks = _.range(6).map(function (i) {
     if (!_.includes(opts.paths, i)) return block({angle: i * 60})
   })

--- a/geo/tile.js
+++ b/geo/tile.js
@@ -1,13 +1,18 @@
 var _ = require('lodash')
+var wedge = require('./wedge.js')
 var Geometry = require('../geometry.js')
 
 module.exports = function (opts) {
   opts = opts || {}
+  children = [
+    wedge({angle: 0}), wedge({angle: 60}), wedge({angle: 120}), 
+    wedge({angle: 180}), wedge({angle: 240}), wedge({angle: 300})
+  ]
   
   return new Geometry({
     props: {
-      fill: opts.fill || '#A5A5A5',
-      stroke: opts.stroke || '#A5A5A5',
+      fill: opts.fill || '#DFE0E2',
+      stroke: opts.stroke || '#DFE0E2',
       type: 'polygon'
     },
 
@@ -25,7 +30,7 @@ module.exports = function (opts) {
       scale: opts.scale
     },
 
-    children: opts.children
+    children: opts.children ? children.concat(opts.children) : children
   })
 
 }

--- a/geo/tile.js
+++ b/geo/tile.js
@@ -1,14 +1,20 @@
 var _ = require('lodash')
 var wedge = require('./wedge.js')
+var block = require('./block.js')
 var Geometry = require('../geometry.js')
 
 module.exports = function (opts) {
   opts = opts || {}
-  children = [
+  var wedges = [
     wedge({angle: 0}), wedge({angle: 60}), wedge({angle: 120}), 
     wedge({angle: 180}), wedge({angle: 240}), wedge({angle: 300})
   ]
-  
+  var blocks = _.range(6).map(function (i) {
+    if (!_.includes(opts.paths, i)) return block({angle: i * 60})
+  })
+  _.remove(blocks, _.isUndefined)
+  var children = wedges.concat(blocks)
+
   return new Geometry({
     props: {
       fill: opts.fill || '#DFE0E2',

--- a/geo/wedge.js
+++ b/geo/wedge.js
@@ -7,16 +7,16 @@ module.exports = function (opts) {
   
   return new Geometry({
     props: {
-      fill: opts.fill || '#DFE0E2',
-      stroke: opts.stroke || '#DFE0E2',
+      fill: opts.fill || '#A5A5A5',
+      stroke: opts.stroke || '#A5A5A5',
       type: 'polygon'
     },
 
     points: [
       [-1/2, Math.sqrt(3)/2],
       [-1/2, Math.sqrt(3)/2/width],
-      [1/2, Math.sqrt(3)/2/width],
-      [1/2, Math.sqrt(3)/2]
+      [1/4 - Math.sin(Math.PI/3) * Math.sqrt(3)/2/width, 1/2 * Math.sin(Math.PI/3) + 1/2 * Math.sqrt(3)/2/width],
+      [1/4 - Math.sin(Math.PI/3) * Math.sqrt(3)/2, 1/2 * Math.sin(Math.PI/3) + 1/2 * Math.sqrt(3)/2],
     ],
 
     transform: {
@@ -24,7 +24,9 @@ module.exports = function (opts) {
       angle: opts.angle || 0
     },
 
-    children: opts.children
+    children: opts.children,
+
+    obstacle: true
   })
 
 }

--- a/geo/wedge.js
+++ b/geo/wedge.js
@@ -15,8 +15,7 @@ module.exports = function (opts) {
     points: [
       [-1/2, Math.sqrt(3)/2],
       [-1/2, Math.sqrt(3)/2/width],
-      [1/4 - Math.sin(Math.PI/3) * Math.sqrt(3)/2/width, 1/2 * Math.sin(Math.PI/3) + 1/2 * Math.sqrt(3)/2/width],
-      [1/4 - Math.sin(Math.PI/3) * Math.sqrt(3)/2, 1/2 * Math.sin(Math.PI/3) + 1/2 * Math.sqrt(3)/2],
+      [1/4 - Math.sin(Math.PI/3) * Math.sqrt(3)/2/width, 1/2 * Math.sin(Math.PI/3) + 1/2 * Math.sqrt(3)/2/width]
     ],
 
     transform: {

--- a/geo/wedge.js
+++ b/geo/wedge.js
@@ -8,7 +8,7 @@ module.exports = function (opts) {
   return new Geometry({
     props: {
       fill: opts.fill || '#A5A5A5',
-      stroke: opts.stroke || '#A5A5A5',
+      stroke: opts.stroke || 'red',
       type: 'polygon'
     },
 

--- a/geo/wedge.js
+++ b/geo/wedge.js
@@ -15,6 +15,7 @@ module.exports = function (opts) {
     points: [
       [-1/2, Math.sqrt(3)/2],
       [-1/2, Math.sqrt(3)/2/width],
+      [-2, Math.sqrt(3)/2/width],
       [1/4 - Math.sin(Math.PI/3) * Math.sqrt(3)/2/width, 1/2 * Math.sin(Math.PI/3) + 1/2 * Math.sqrt(3)/2/width]
     ],
 

--- a/geometry.js
+++ b/geometry.js
@@ -15,10 +15,10 @@ function Geometry(data) {
     this.children = data.children ? [data.children] : []
   }
   this.transform = data.transform ? transform(data.transform) : transform()  
-  this.move()
+  this.stage()
 }
 
-Geometry.prototype.move = function(transform, opts) {
+Geometry.prototype.stage = function(transform, opts) {
   var self = this
   opts = opts || {}
   transform = transform || self.transform
@@ -26,7 +26,7 @@ Geometry.prototype.move = function(transform, opts) {
   self.points = op(self.points)
   if (self.children.length) {
     _.forEach(self.children, function(child) {
-      child.move(transform, opts)
+      child.stage(transform, opts)
     })
   }
 }
@@ -109,17 +109,6 @@ Geometry.prototype.draw = function(context, camera, opts) {
   } else {
     throw Error('Order ' + opts.order + ' not recognized')
   }
-}
-
-Geometry.prototype.clone = function() {
-  var self = this
-  return new Geometry({
-    props: _.cloneDeep(self.props),
-    points: self.points,
-    obstacle: self.obstacle,
-    children: self.children,
-    transform: self.transform
-  })
 }
 
 module.exports = Geometry

--- a/geometry.js
+++ b/geometry.js
@@ -31,6 +31,16 @@ Geometry.prototype.stage = function(transform, opts) {
   }
 }
 
+Geometry.prototype.unstage = function() {
+  var self = this
+  var t = transform({
+    position: self.transform.position(),
+    scale: self.transform.scale(),
+    angle: self.transform.angle()
+  })
+  self.stage(t, {invert: true})
+}
+
 Geometry.prototype.contains = function(point) {
   var self = this
   return inside(point, self.points)

--- a/geometry.js
+++ b/geometry.js
@@ -1,4 +1,6 @@
 var _ = require('lodash')
+var inside = require('point-in-polygon')
+var sat = require('sat')
 var transform = require('./transform.js')
 
 function Geometry(data) {
@@ -26,6 +28,15 @@ Geometry.prototype.move = function(transform, opts) {
       child.move(transform, opts)
     })
   }
+}
+
+Geometry.prototype.contains = function(point) {
+  var self = this
+  return inside(point, self.points)
+}
+
+Geometry.prototype.intersects = function(geometry) {
+
 }
 
 Geometry.prototype.polygon = function(context, points) {

--- a/movement.js
+++ b/movement.js
@@ -2,24 +2,39 @@ var _ = require('lodash')
 var transform = require('./transform.js')
 
 function Movement(data) {
-  this.velocity = data.velocity || transform({position: [0, 0], angle: 0, scale: 0})
+  this.velocity = data.velocity || transform({position: [0, 0], angle: 0, scale: 1})
   this.speed = data.speed || 1
   this.friction = data.friction || 0
-  this.keymap = data.keymap || ['A','D','S','W','Q','E',',','.']
+  this.keymap = data.keymap || {position: [['A','D'],['S','W']], angle: ['Q','E'], scale: [',','.']}
 }
 
 Movement.prototype.update = function(keys) {
-  var self = this
-  var down = []
-  self.keymap.forEach(function (key, i) {if (key in keys) down.push(i)})
-  var inc = function(ind) {return (down.indexOf(ind) > -1 ? self.speed : 0)}
-  var dec = function(ind) {return (down.indexOf(ind) > -1 ? -self.speed : 0)}
-  var delta = {
-    position: [dec(0) + inc(1), dec(2) + inc(3)],
-    angle: dec(4) + inc(5),
-    scale: dec(6) + inc(7)
+  var keymap = this.keymap
+
+  var d = {}
+
+  if (keymap.position) {
+    d.position = [0, 0]
+    if (keymap.position[0][0] in keys) d.position[0] += this.speed
+    if (keymap.position[0][1] in keys) d.position[0] -= this.speed
+    if (keymap.position[1][0] in keys) d.position[1] += this.speed
+    if (keymap.position[1][1] in keys) d.position[1] -= this.speed
   }
-  self.velocity.add(delta)
+
+  if (keymap.angle) {
+    d.angle = 0
+    if (keymap.angle[0] in keys) d.angle += this.speed
+    if (keymap.angle[1] in keys) d.angle -= this.speed
+  }
+
+  if (keymap.scale) {
+    d.scale = 0
+    if (keymap.scale[0] in keys) d.scale += this.speed * 0.001
+    if (keymap.scale[1] in keys) d.scale -= this.speed * 0.001
+  }
+
+  this.velocity.add(d)
+
 }
 
 Movement.prototype.apply = function(transform) {
@@ -31,6 +46,9 @@ Movement.prototype.apply = function(transform) {
   ]
   delta.angle = this.velocity.angle()
   delta.scale = this.velocity.scale()
+  //console.log(this.velocity.scale())
+  console.log(delta.scale)
+  //console.log(transform.scale())
   transform.add(delta)
   this.dampen()
 }

--- a/movement.js
+++ b/movement.js
@@ -1,0 +1,47 @@
+var _ = require('lodash')
+var transform = require('./transform.js')
+
+function Movement(data) {
+  this.velocity = data.velocity || transform({position: [0, 0], angle: 0, scale: 0})
+  this.speed = data.speed || 1
+  this.friction = data.friction || 0
+  this.keymap = data.keymap || ['A','D','S','W','Q','E',',','.']
+}
+
+Movement.prototype.update = function(keys) {
+  var self = this
+  var down = []
+  self.keymap.forEach(function (key, i) {if (key in keys) down.push(i)})
+  var inc = function(ind) {return (down.indexOf(ind) > -1 ? self.speed : 0)}
+  var dec = function(ind) {return (down.indexOf(ind) > -1 ? -self.speed : 0)}
+  var delta = {
+    position: [dec(0) + inc(1), dec(2) + inc(3)],
+    angle: dec(4) + inc(5),
+    scale: dec(6) + inc(7)
+  }
+  self.velocity.add(delta)
+}
+
+Movement.prototype.apply = function(transform) {
+  var rad = transform.angle() * Math.PI / 180
+  var delta = {}
+  delta.position = [
+    this.velocity.position()[0] * Math.cos(rad) - this.velocity.position()[1] * Math.sin(rad),
+    this.velocity.position()[0] * Math.sin(rad) + this.velocity.position()[1] * Math.cos(rad)
+  ]
+  delta.angle = this.velocity.angle()
+  delta.scale = this.velocity.scale()
+  transform.add(delta)
+  this.dampen()
+}
+
+Movement.prototype.dampen = function() {
+  var delta = {
+    position: [this.friction, this.friction],
+    angle: this.friction,
+    scale: this.friction
+  }
+  this.velocity.multiply(delta)
+}
+
+module.exports = Movement

--- a/movement.js
+++ b/movement.js
@@ -2,7 +2,7 @@ var _ = require('lodash')
 var transform = require('./transform.js')
 
 function Movement(data) {
-  this.velocity = data.velocity || transform({position: [0, 0], angle: 0, scale: 1})
+  this.velocity = data.velocity || {position: [0, 0], angle: 0, scale: 0}
   this.speed = data.speed || 1
   this.friction = data.friction || 0
   this.keymap = data.keymap || {position: [['A','D'],['S','W']], angle: ['Q','E'], scale: [',','.']}
@@ -11,29 +11,22 @@ function Movement(data) {
 Movement.prototype.update = function(keys) {
   var keymap = this.keymap
 
-  var d = {}
-
   if (keymap.position) {
-    d.position = [0, 0]
-    if (keymap.position[0][0] in keys) d.position[0] += this.speed
-    if (keymap.position[0][1] in keys) d.position[0] -= this.speed
-    if (keymap.position[1][0] in keys) d.position[1] += this.speed
-    if (keymap.position[1][1] in keys) d.position[1] -= this.speed
+    if (keymap.position[0][0] in keys) this.velocity.position[0] += this.speed
+    if (keymap.position[0][1] in keys) this.velocity.position[0] -= this.speed
+    if (keymap.position[1][0] in keys) this.velocity.position[1] += this.speed
+    if (keymap.position[1][1] in keys) this.velocity.position[1] -= this.speed
   }
 
   if (keymap.angle) {
-    d.angle = 0
-    if (keymap.angle[0] in keys) d.angle += this.speed
-    if (keymap.angle[1] in keys) d.angle -= this.speed
+    if (keymap.angle[0] in keys) this.velocity.angle += this.speed
+    if (keymap.angle[1] in keys) this.velocity.angle -= this.speed
   }
 
   if (keymap.scale) {
-    d.scale = 0
-    if (keymap.scale[0] in keys) d.scale += this.speed * 0.001
-    if (keymap.scale[1] in keys) d.scale -= this.speed * 0.001
+    if (keymap.scale[0] in keys) this.velocity.scale += this.speed*.01
+    if (keymap.scale[1] in keys) this.velocity.scale -= this.speed*.01
   }
-
-  this.velocity.add(d)
 
 }
 
@@ -44,22 +37,18 @@ Movement.prototype.apply = function(transform) {
     this.velocity.position()[0] * Math.cos(rad) - this.velocity.position()[1] * Math.sin(rad),
     this.velocity.position()[0] * Math.sin(rad) + this.velocity.position()[1] * Math.cos(rad)
   ]
-  delta.angle = this.velocity.angle()
-  delta.scale = this.velocity.scale()
   //console.log(this.velocity.scale())
-  console.log(delta.scale)
-  //console.log(transform.scale())
-  transform.add(delta)
+  delta.angle = this.velocity.angle()
+  delta.scale = Math.exp(this.velocity.scale())
+  transform.compose(delta)
   this.dampen()
 }
 
 Movement.prototype.dampen = function() {
-  var delta = {
-    position: [this.friction, this.friction],
-    angle: this.friction,
-    scale: this.friction
-  }
-  this.velocity.multiply(delta)
+  this.velocity.position[0] *= this.friction
+  this.velocity.position[1] *= this.friction
+  this.velocity.angle *= this.friction
+  this.velocity.scale[0] *= this.friction
 }
 
 module.exports = Movement

--- a/movement.js
+++ b/movement.js
@@ -5,10 +5,10 @@ function Movement(data) {
   this.velocity = data.velocity || {position: [0, 0], angle: 0, scale: 0}
   this.speed = data.speed || 1
   this.friction = data.friction || 0
-  this.keymap = data.keymap || {position: [['A','D'],['S','W']], angle: ['Q','E'], scale: [',','.']}
+  this.keymap = data.keymap || {position: [['D','A'],['W','S']], angle: ['E','Q'], scale: [',','.']}
 }
 
-Movement.prototype.update = function(keys) {
+Movement.prototype.compute = function(keys, angle) {
   var keymap = this.keymap
 
   if (keymap.position) {
@@ -27,28 +27,30 @@ Movement.prototype.update = function(keys) {
     if (keymap.scale[0] in keys) this.velocity.scale += this.speed*.01
     if (keymap.scale[1] in keys) this.velocity.scale -= this.speed*.01
   }
+  
+  var delta = this.delta(angle)
+  this.dampen()
+  return delta
 
 }
 
-Movement.prototype.apply = function(transform) {
-  var rad = transform.angle() * Math.PI / 180
-  var delta = {}
-  delta.position = [
-    this.velocity.position()[0] * Math.cos(rad) - this.velocity.position()[1] * Math.sin(rad),
-    this.velocity.position()[0] * Math.sin(rad) + this.velocity.position()[1] * Math.cos(rad)
-  ]
-  //console.log(this.velocity.scale())
-  delta.angle = this.velocity.angle()
-  delta.scale = Math.exp(this.velocity.scale())
-  transform.compose(delta)
-  this.dampen()
+Movement.prototype.delta = function(angle) {
+  var rad = angle * Math.PI / 180 || 0
+  return {
+    position: [
+      this.velocity.position[0] * Math.cos(rad) - this.velocity.position[1] * Math.sin(rad),
+      this.velocity.position[0] * Math.sin(rad) + this.velocity.position[1] * Math.cos(rad)
+    ],
+    angle: this.velocity.angle,
+    scale: Math.exp(this.velocity.scale)
+  }
 }
 
 Movement.prototype.dampen = function() {
   this.velocity.position[0] *= this.friction
   this.velocity.position[1] *= this.friction
   this.velocity.angle *= this.friction
-  this.velocity.scale[0] *= this.friction
+  this.velocity.scale *= this.friction
 }
 
 module.exports = Movement

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "crtrdg-player": "0.0.1",
     "inherits": "~2.0.0",
     "lodash": "^3.10.1",
-    "mathjs": "^2.4.0"
+    "mathjs": "^2.4.0",
+    "point-in-polygon": "^1.0.0",
+    "polygon-aabb": "^1.0.0",
+    "sat": "^0.5.0"
   },
   "devDependencies": {
     "beefy": "~0.4.0",

--- a/player.js
+++ b/player.js
@@ -50,8 +50,6 @@ Player.prototype.move = function(velocity, world) {
   var collisions = world.intersects(self.geometry)
   if (collisions) {
     var ind = _.indexOf(collisions, _.max(collisions, function (i) {return i.response.overlap}))
-    console.log(collisions)
-    console.log(collisions[ind].response.overlap)
     var t = transform({
       position: self.geometry.transform.position(),
       scale: self.geometry.transform.scale(),

--- a/player.js
+++ b/player.js
@@ -44,7 +44,7 @@ Player.prototype.move = function(velocity, world) {
   ]
   delta.angle = velocity.angle
 
-  self.geometry.transform.update(delta)
+  self.geometry.transform.add(delta)
   self.geometry.stage(self.geometry.transform)
 
   var collisions = world.intersects(self.geometry)
@@ -62,7 +62,7 @@ Player.prototype.move = function(velocity, world) {
         -0.2 * delta.position[1] + 0.5 * collisions[ind].response.overlapV.y, 
       ]
     }
-    self.geometry.transform.update(correction)
+    self.geometry.transform.add(correction)
     self.geometry.stage(self.geometry.transform)
   }
 

--- a/player.js
+++ b/player.js
@@ -50,6 +50,8 @@ Player.prototype.move = function(velocity, world) {
   var collisions = world.intersects(self.geometry)
   if (collisions) {
     var ind = _.indexOf(collisions, _.max(collisions, function (i) {return i.response.overlap}))
+    console.log(collisions)
+    console.log(collisions[ind].response.overlap)
     var t = transform({
       position: self.geometry.transform.position(),
       scale: self.geometry.transform.scale(),

--- a/player.js
+++ b/player.js
@@ -34,7 +34,7 @@ Player.prototype.move = function(velocity, world) {
     scale: self.geometry.transform.scale(),
     angle: self.geometry.transform.angle()
   })
-  self.geometry.move(t, {invert: true})
+  self.geometry.stage(t, {invert: true})
 
   var rad = t.angle() * Math.PI / 180
   var delta = {}
@@ -45,15 +45,15 @@ Player.prototype.move = function(velocity, world) {
   delta.angle = velocity.angle
 
   self.geometry.transform.update(delta)
-  self.geometry.move(self.geometry.transform)
+  self.geometry.stage(self.geometry.transform)
 
   var collisions = world.intersects(self.geometry)
   if (collisions) {
     // find colliding object with largest overlap vector
     var ind = _.indexOf(collisions, _.max(collisions, function (i) {return i.response.overlap}))
     // adjust using overlap vector
-    self.velocity.position[0] = 2 * collisions[ind].response.overlapV.x
-    self.velocity.position[1] = 2 * collisions[ind].response.overlapV.y
+    self.velocity.position[0] -= self.velocity.position[0]
+    self.velocity.position[1] -= self.velocity.position[1]
   }
 
 }

--- a/player.js
+++ b/player.js
@@ -4,104 +4,55 @@ var aabb = require('aabb-2d')
 var math = require('mathjs')
 var transform = require('./transform.js')
 var circle = require('./geo/circle.js')
+var Movement = require('./movement.js')
 var Entity = require('crtrdg-entity')
 
 module.exports = Player;
 inherits(Player, Entity);
 
 function Player(opts){
-  this.velocity = opts.velocity
-  this.speed = opts.speed
-  this.friction = opts.friction
   this.geometry = circle({
     fill: opts.color, 
     stroke: opts.color,
-    scale: 2,
-    position: opts.position,
-    angle: opts.angle,
+    scale: opts.scale,
     children: [
       circle({fill: '#EB8686', stroke: '#EB8686', position: [-0.75, -1], scale: 0.5}), 
       circle({fill: '#EB8686', stroke: '#EB8686', position: [0.75, -1], scale: 0.5})
     ]
   })
+  this.movement = new Movement({
+    speed: opts.speed,
+    friction: opts.friction,
+    keymap: {position: [['E','Q'],['S','W']], angle: ['D','A']}
+  })
 }
 
-Player.prototype.move = function(velocity, world) {
+Player.prototype.move = function(keyboard, world) {
   var self = this
 
-  var t = transform({
-    position: self.geometry.transform.position(),
-    scale: self.geometry.transform.scale(),
-    angle: self.geometry.transform.angle()
-  })
-  self.geometry.stage(t, {invert: true})
+  var delta = self.movement.compute(keyboard.keysDown, self.geometry.transform.angle())
 
-  var rad = t.angle() * Math.PI / 180
-  var delta = {}
-  delta.position = [
-    velocity.position[0] * Math.cos(rad) - velocity.position[1] * Math.sin(rad),
-    velocity.position[0] * Math.sin(rad) + velocity.position[1] * Math.cos(rad)
-  ]
-  delta.angle = velocity.angle
-
-  self.geometry.transform.add(delta)
+  self.geometry.unstage()
+  self.geometry.transform.compose(delta)
   self.geometry.stage(self.geometry.transform)
 
-  var collisions = world.intersects(self.geometry)
+  var collisions = world.intersects(self.geometry) 
   if (collisions) {
     var ind = _.indexOf(collisions, _.max(collisions, function (i) {return i.response.overlap}))
-    var t = transform({
-      position: self.geometry.transform.position(),
-      scale: self.geometry.transform.scale(),
-      angle: self.geometry.transform.angle()
-    })
-    self.geometry.stage(t, {invert: true})
     var correction = {
       position: [
         -0.2 * delta.position[0] + 0.5 * collisions[ind].response.overlapV.x, 
         -0.2 * delta.position[1] + 0.5 * collisions[ind].response.overlapV.y, 
       ]
     }
-    self.geometry.transform.add(correction)
+    self.geometry.unstage()
+    self.geometry.transform.compose(correction)
     self.geometry.stage(self.geometry.transform)
-  }
-
-}
-
-Player.prototype.keyboardInput = function(keyboard){
-  if ('E' in keyboard.keysDown){
-    this.velocity.position[0] = this.speed;
-  }
-
-  if ('Q' in keyboard.keysDown){
-    this.velocity.position[0] = -this.speed;
-  }
-
-  if ('S' in keyboard.keysDown) {
-    this.velocity.position[1] = this.speed;
-  }
-
-  if ('W' in keyboard.keysDown) {
-    this.velocity.position[1] = -this.speed;
-  }
-
-  if ('A' in keyboard.keysDown) {
-    this.velocity.angle = -this.speed * 2
-  }
-
-  if ('D' in keyboard.keysDown) {
-    this.velocity.angle = this.speed * 2
   }
 }
 
 Player.prototype.draw = function(context, camera) {
   this.geometry.draw(context, camera, {order: 'bottom'})
-}
-
-Player.prototype.dampen = function() {
-  this.velocity.position[0] *= this.friction
-  this.velocity.position[1] *= this.friction
-  this.velocity.angle *= this.friction
 }
 
 Player.prototype.position = function() {

--- a/player.js
+++ b/player.js
@@ -58,8 +58,8 @@ Player.prototype.move = function(velocity, world) {
     self.geometry.stage(t, {invert: true})
     var correction = {
       position: [
-        -delta.position[0] + collisions[ind].response.overlapV.x, 
-        -delta.position[1] + collisions[ind].response.overlapV.y, 
+        -0.2 * delta.position[0] + 0.5 * collisions[ind].response.overlapV.x, 
+        -0.2 * delta.position[1] + 0.5 * collisions[ind].response.overlapV.y, 
       ]
     }
     self.geometry.transform.update(correction)

--- a/player.js
+++ b/player.js
@@ -24,10 +24,9 @@ function Player(opts){
       circle({fill: '#EB8686', stroke: '#EB8686', position: [0.75, -1], scale: 0.5})
     ]
   })
-
 }
 
-Player.prototype.move = function(velocity, world){
+Player.prototype.move = function(velocity, world) {
   var self = this
 
   var t = transform({
@@ -45,19 +44,18 @@ Player.prototype.move = function(velocity, world){
   ]
   delta.angle = velocity.angle
 
-  if (!world.contains(t.update(delta).position())) {
-    console.log('outside')
-  }
-
-  //console.log(self.geometry.transform.position())
-  //transform.update(delta)
-  //console.log(self.geometry.transform.position())
-  //if (!world.contains(transform.update(delta))) {
-  //  console.log('we got here')
   self.geometry.transform.update(delta)
   self.geometry.move(self.geometry.transform)
-  //}
-  
+
+  var collisions = world.intersects(self.geometry)
+  if (collisions) {
+    // find colliding object with largest overlap vector
+    var ind = _.indexOf(collisions, _.max(collisions, function (i) {return i.response.overlap}))
+    // adjust using overlap vector
+    self.velocity.position[0] = 2 * collisions[ind].response.overlapV.x
+    self.velocity.position[1] = 2 * collisions[ind].response.overlapV.y
+  }
+
 }
 
 Player.prototype.keyboardInput = function(keyboard){

--- a/player.js
+++ b/player.js
@@ -49,11 +49,21 @@ Player.prototype.move = function(velocity, world) {
 
   var collisions = world.intersects(self.geometry)
   if (collisions) {
-    // find colliding object with largest overlap vector
     var ind = _.indexOf(collisions, _.max(collisions, function (i) {return i.response.overlap}))
-    // adjust using overlap vector
-    self.velocity.position[0] -= self.velocity.position[0]
-    self.velocity.position[1] -= self.velocity.position[1]
+    var t = transform({
+      position: self.geometry.transform.position(),
+      scale: self.geometry.transform.scale(),
+      angle: self.geometry.transform.angle()
+    })
+    self.geometry.stage(t, {invert: true})
+    var correction = {
+      position: [
+        -delta.position[0] + collisions[ind].response.overlapV.x, 
+        -delta.position[1] + collisions[ind].response.overlapV.y, 
+      ]
+    }
+    self.geometry.transform.update(correction)
+    self.geometry.stage(self.geometry.transform)
   }
 
 }

--- a/player.js
+++ b/player.js
@@ -1,3 +1,4 @@
+var _ = require('lodash')
 var inherits = require('inherits')
 var aabb = require('aabb-2d')
 var math = require('mathjs')
@@ -23,24 +24,40 @@ function Player(opts){
       circle({fill: '#EB8686', stroke: '#EB8686', position: [0.75, -1], scale: 0.5})
     ]
   })
+
 }
 
-Player.prototype.move = function(velocity){
+Player.prototype.move = function(velocity, world){
   var self = this
 
-  var transform = self.geometry.transform
-  self.geometry.move(transform, {invert: true})
+  var t = transform({
+    position: self.geometry.transform.position(),
+    scale: self.geometry.transform.scale(),
+    angle: self.geometry.transform.angle()
+  })
+  self.geometry.move(t, {invert: true})
 
-  var rad = transform.angle() * Math.PI / 180
+  var rad = t.angle() * Math.PI / 180
   var delta = {}
   delta.position = [
     velocity.position[0] * Math.cos(rad) - velocity.position[1] * Math.sin(rad),
     velocity.position[0] * Math.sin(rad) + velocity.position[1] * Math.cos(rad)
   ]
   delta.angle = velocity.angle
-  
+
+  if (!world.contains(t.update(delta).position())) {
+    console.log('outside')
+  }
+
+  //console.log(self.geometry.transform.position())
+  //transform.update(delta)
+  //console.log(self.geometry.transform.position())
+  //if (!world.contains(transform.update(delta))) {
+  //  console.log('we got here')
   self.geometry.transform.update(delta)
   self.geometry.move(self.geometry.transform)
+  //}
+  
 }
 
 Player.prototype.keyboardInput = function(keyboard){

--- a/transform.js
+++ b/transform.js
@@ -16,23 +16,11 @@ module.exports = function transform(opts) {
     return this
   }
 
-  var add = function (opts) {
+  var compose = function (opts) {
     position = _.isArray(opts.position)
-      ? [position[0] + opts.position[0], position[1] + opts.position[1]] 
-      : position
+      ? [position[0] + opts.position[0], position[1] + opts.position[1]] : position
     angle = _.isNumber(opts.angle) ? angle + opts.angle : angle
-    //scale = _.isNumber(opts.scale) ? Math.exp(Math.log(scale) + opts.scale) : scale
-    scale = _.isNumber(opts.scale) ? scale*Math.exp(opts.scale) : scale
-    rotation = rotmat(angle)
-    return this
-  }
-
-  var multiply = function (opts) {
-    position = _.isArray(opts.position)
-      ? [position[0] * opts.position[0], position[1] * opts.position[1]] 
-      : position
-    angle = _.isNumber(opts.angle) ? angle * opts.angle : angle
-    scale = _.isNumber(opts.scale) ? scale + opts.scale : scale
+    scale = _.isNumber(opts.scale) ? scale * opts.scale : scale
     rotation = rotmat(angle)
     return this
   }
@@ -79,8 +67,7 @@ module.exports = function transform(opts) {
   return {
     apply: apply,
     invert: invert,
-    add: add,
-    multiply: multiply,
+    compose: compose,
     set: set,
     position: function () {return position},
     scale: function () {return scale},

--- a/transform.js
+++ b/transform.js
@@ -1,3 +1,5 @@
+var _ = require('lodash')
+
 module.exports = function transform(opts) {
 
   opts = opts || {}
@@ -7,19 +9,29 @@ module.exports = function transform(opts) {
   var rotation
   
   var set = function (opts) {
-    position = opts.position ? opts.position : position
-    scale = opts.scale ? opts.scale : scale
-    angle = opts.angle ? opts.angle : angle
+    position = _.isArray(opts.position) ? opts.position : position
+    scale = _.isNumber(opts.scale) ? opts.scale : scale
+    angle = _.isNumber(opts.angle) ? opts.angle : angle
     rotation = rotmat(angle)
     return this
   }
 
-  var update = function (opts) {
-    position = opts.position 
+  var add = function (opts) {
+    position = _.isArray(opts.position)
       ? [position[0] + opts.position[0], position[1] + opts.position[1]] 
       : position
-    angle = opts.angle ? angle + opts.angle : angle
-    scale = opts.scale ? Math.exp(Math.log(scale) + opts.scale) : scale
+    angle = _.isNumber(opts.angle) ? angle + opts.angle : angle
+    scale = _.isNumber(opts.scale) ? scale + opts.scale : scale
+    rotation = rotmat(angle)
+    return this
+  }
+
+  var multiply = function (opts) {
+    position = _.isArray(opts.position)
+      ? [position[0] * opts.position[0], position[1] * opts.position[1]] 
+      : position
+    angle = _.isNumber(opts.angle) ? angle * opts.angle : angle
+    scale = _.isNumber(opts.scale) ? scale * opts.scale : scale
     rotation = rotmat(angle)
     return this
   }
@@ -66,8 +78,9 @@ module.exports = function transform(opts) {
   return {
     apply: apply,
     invert: invert,
+    add: add,
+    multiply: multiply,
     set: set,
-    update: update,
     position: function () {return position},
     scale: function () {return scale},
     angle: function () {return angle},

--- a/transform.js
+++ b/transform.js
@@ -1,4 +1,4 @@
-module.exports = function(opts) {
+module.exports = function transform(opts) {
 
   opts = opts || {}
   var position = [0, 0]
@@ -11,6 +11,7 @@ module.exports = function(opts) {
     scale = opts.scale ? opts.scale : scale
     angle = opts.angle ? opts.angle : angle
     rotation = rotmat(angle)
+    return this
   }
 
   var update = function (opts) {
@@ -20,6 +21,7 @@ module.exports = function(opts) {
     angle = opts.angle ? angle + opts.angle : angle
     scale = opts.scale ? Math.exp(Math.log(scale) + opts.scale) : scale
     rotation = rotmat(angle)
+    return this
   }
 
   var rotmat = function (angle) {

--- a/transform.js
+++ b/transform.js
@@ -21,7 +21,8 @@ module.exports = function transform(opts) {
       ? [position[0] + opts.position[0], position[1] + opts.position[1]] 
       : position
     angle = _.isNumber(opts.angle) ? angle + opts.angle : angle
-    scale = _.isNumber(opts.scale) ? scale + opts.scale : scale
+    //scale = _.isNumber(opts.scale) ? Math.exp(Math.log(scale) + opts.scale) : scale
+    scale = _.isNumber(opts.scale) ? scale*Math.exp(opts.scale) : scale
     rotation = rotmat(angle)
     return this
   }
@@ -31,7 +32,7 @@ module.exports = function transform(opts) {
       ? [position[0] * opts.position[0], position[1] * opts.position[1]] 
       : position
     angle = _.isNumber(opts.angle) ? angle * opts.angle : angle
-    scale = _.isNumber(opts.scale) ? scale * opts.scale : scale
+    scale = _.isNumber(opts.scale) ? scale + opts.scale : scale
     rotation = rotmat(angle)
     return this
   }

--- a/world.js
+++ b/world.js
@@ -17,38 +17,38 @@ function World(opts) {
     tile({
       position: [0, 0],
       scale: 50,
-      paths: [0, 2, 4],
+      paths: [0, 1, 2, 3, 4, 5],
       children: [circle({fill: 'white', stroke: 'white', scale: 0.1})]
     }),
     tile({
       position: [-1, 0],
       scale: 50,
-      paths: [0, 4, 5]
+      paths: [0, 1, 2, 3, 4, 5]
     }),
     tile({
       position: [0, 1],
       scale: 50,
-      paths: [2, 3, 4]
+      paths: [0, 1, 2, 3, 4, 5]
     }),
     tile({
       position: [-1, 1],
       scale: 50,
-      paths: [4, 5]
+      paths: [0, 1, 2, 3, 4, 5]
     }),
     tile({
       position: [1, -1],
       scale: 50,
-      paths: [2]
+      paths: [0, 1, 2, 3, 4, 5]
     }),
     tile({
       position: [1, 0],
       scale: 50,
-      paths: [1, 3]
+      paths: [0, 1, 2, 3, 4, 5]
     }),
     tile({
       position: [0, -1],
       scale: 50,
-      paths: [1, 5]
+      paths: [0, 1, 2, 3, 4, 5]
     })
   ]
 

--- a/world.js
+++ b/world.js
@@ -17,40 +17,38 @@ function World(opts) {
     tile({
       position: [0, 0],
       scale: 50,
-      children: [
-        circle({fill: 'white', stroke: 'white', scale: 0.1}),
-        block({angle: 0}), block({angle: 120}), block({angle: 240})
-      ]
+      paths: [0, 2, 4],
+      children: [circle({fill: 'white', stroke: 'white', scale: 0.1})]
     }),
     tile({
       position: [-1, 0],
       scale: 50,
-      children: [block({angle: 60}), block({angle: 300}), wedge({angle: 0})]
+      paths: [0, 4, 5]
     }),
     tile({
       position: [0, 1],
       scale: 50,
-      children: [block({angle: 180}), block({angle: 240}), block({angle: 300})]
+      paths: [2, 3, 4]
     }),
     tile({
       position: [-1, 1],
       scale: 50,
-      children: [block({angle: 240}), block({angle: 300})]
+      paths: [4, 5]
     }),
     tile({
       position: [1, -1],
       scale: 50,
-      children: [block({angle: 180})]
+      paths: [2]
     }),
     tile({
       position: [1, 0],
       scale: 50,
-      children: [block({angle: 120}), block({angle: 240})]
+      paths: [1, 3]
     }),
     tile({
       position: [0, -1],
       scale: 50,
-      children: [block({angle: 0}), block({angle: 120})]
+      paths: [1, 5]
     })
   ]
 

--- a/world.js
+++ b/world.js
@@ -80,8 +80,6 @@ World.prototype.locate = function(point) {
 World.prototype.intersects = function(geometry) {
   var self = this
   var results = []
-  var point = geometry.transform.position()
-  var ind = self.locate(point)
   this.tiles.forEach(function (tile) {
     tile.children.forEach(function (child) {
       if (child.obstacle) {

--- a/world.js
+++ b/world.js
@@ -17,38 +17,38 @@ function World(opts) {
     tile({
       position: [0, 0],
       scale: 50,
-      paths: [0, 1, 2, 3, 4, 5],
+      paths: [0, 2, 4],
       children: [circle({fill: 'white', stroke: 'white', scale: 0.1})]
     }),
     tile({
       position: [-1, 0],
       scale: 50,
-      paths: [0, 1, 2, 3, 4, 5]
+      paths: [0, 4, 5]
     }),
     tile({
       position: [0, 1],
       scale: 50,
-      paths: [0, 1, 2, 3, 4, 5]
+      paths: [2, 3, 4]
     }),
     tile({
       position: [-1, 1],
       scale: 50,
-      paths: [0, 1, 2, 3, 4, 5]
+      paths: [4, 5]
     }),
     tile({
       position: [1, -1],
       scale: 50,
-      paths: [0, 1, 2, 3, 4, 5]
+      paths: [2]
     }),
     tile({
       position: [1, 0],
       scale: 50,
-      paths: [0, 1, 2, 3, 4, 5]
+      paths: [1, 3]
     }),
     tile({
       position: [0, -1],
       scale: 50,
-      paths: [0, 1, 2, 3, 4, 5]
+      paths: [1, 5]
     })
   ]
 


### PR DESCRIPTION
This PR adds collision detection between geometries in general, and between player and world in particular. It's all working nicely, though I want to do some clean up and refactoring.

Major change to maze structure: rather than think about paths as the primary geometry making up the environment, we now use `blocks` and `wedges`. Blocks are where paths would be, wedges fill the space in between, and paths just become the empty space. The major advance is that we can do simple and sensible collision detection between the player and these elements, which was otherwise becoming very complex. Adding obstacles now becomes easy because they occupy space just like `wedges` and `blocks`.

We may need to slightly tweak how we think about schemas, etc, but for the purpose of collision detection it's clearly a win.
