### PR TITLE
Adding ring

### DIFF
--- a/game.js
+++ b/game.js
@@ -35,10 +35,10 @@ var camera = new Camera({
 })
 
 var ring = new Ring({
-  count: 30,
   size: 0.82 * game.width/2,
+  position: [game.width/2, game.width/2],
   extent: 0.1 * game.width/2,
-  position: [game.width/2, game.width/2]
+  count: 30
 })
 
 var mask = new Mask({

--- a/game.js
+++ b/game.js
@@ -1,15 +1,17 @@
 var _ = require('lodash')
+var color = require('d3-color')
 var Game = require('crtrdg-gameloop');
 var Keyboard = require('crtrdg-keyboard');
 var Mouse = require('crtrdg-mouse');
 var Player = require('./player.js')
 var Camera = require('./camera.js')
 var World = require('./world.js')
+var Ring = require('./ring.js')
 
 var game = new Game({
   canvas: 'game',
-  width: 600,
-  height: 600
+  width: 680,
+  height: 680
 });
 
 var keyboard = new Keyboard(game)
@@ -31,11 +33,19 @@ var camera = new Camera({
   yoked: true
 })
 
+var ring = new Ring({
+  count: 30,
+  size: 0.82 * game.width/2,
+  extent: 0.1 * game.width/2,
+  position: [game.width/2, game.width/2]
+})
+
 var world = new World({player: player})
 
 player.addTo(game)
 camera.addTo(game)
 world.addTo(game)
+ring.addTo(game)
 
 player.on('update', function(interval) {
   this.move(keyboard, world)
@@ -51,6 +61,15 @@ camera.on('update', function(interval) {
   this.move(keyboard)
 })
 
+ring.on('update', function(interval) {
+  var colors = _.range(30).map(function (i) {
+    var r = Math.sqrt(Math.pow(player.position()[0], 2) + Math.pow(player.position()[1], 2)) / 100
+    var c = color.hsl(player.angle(), 0.5, Math.max(1 - Math.max(r - 0.25, 0) - 0.35, 0))
+    return c.toString()
+  })
+  this.update(colors)
+})
+
 world.on('location', function(msg) {
   //console.log(msg)
 })
@@ -60,9 +79,9 @@ game.on('draw-background', function(context) {
   context.beginPath()
   context.moveTo(0, 0)
   _.range(7).map(function(i) {
-    var dx =  (Math.cos(i * 2 * Math.PI / 6) + 1) * game.width / 2
-    var dy =  (Math.sin(i * 2 * Math.PI / 6) + 1) * game.height / 2
-    context.lineTo(dx, dy)
+    var dx =  (Math.cos(i * 2 * Math.PI / 6)) * 0.8 * game.width/2
+    var dy =  (Math.sin(i * 2 * Math.PI / 6)) * 0.8 * game.width/2
+    context.lineTo(dx + game.width/2, dy + game.height/2)
   })
   context.fillStyle = 'rgb(90,90,90)'
   context.fill()
@@ -78,6 +97,7 @@ game.on('draw', function(context) {
   world.draw(context, camera)
   player.draw(context, camera)
   context.restore()
+  ring.draw(context)
 })
 
 game.on('pause', function(){})

--- a/game.js
+++ b/game.js
@@ -7,11 +7,12 @@ var Player = require('./player.js')
 var Camera = require('./camera.js')
 var World = require('./world.js')
 var Ring = require('./ring.js')
+var Mask = require('./mask.js')
 
 var game = new Game({
   canvas: 'game',
-  width: 680,
-  height: 680
+  width: 650,
+  height: 650
 });
 
 var keyboard = new Keyboard(game)
@@ -40,6 +41,11 @@ var ring = new Ring({
   position: [game.width/2, game.width/2]
 })
 
+var mask = new Mask({
+  size: 0.8 * game.width/2,
+  position: [game.width/2, game.width/2]
+})
+
 var world = new World({player: player})
 
 player.addTo(game)
@@ -63,8 +69,8 @@ camera.on('update', function(interval) {
 
 ring.on('update', function(interval) {
   var colors = _.range(30).map(function (i) {
-    var r = Math.sqrt(Math.pow(player.position()[0], 2) + Math.pow(player.position()[1], 2)) / 100
-    var c = color.hsl(player.angle(), 0.5, Math.max(1 - Math.max(r - 0.25, 0) - 0.35, 0))
+    var h = Math.ceil(Math.random() * 360)
+    var c = color.hsl(h, 0.5, 0.5)
     return c.toString()
   })
   this.update(colors)
@@ -74,29 +80,15 @@ world.on('location', function(msg) {
   //console.log(msg)
 })
 
-game.on('draw-background', function(context) {
-  context.save()
-  context.beginPath()
-  context.moveTo(0, 0)
-  _.range(7).map(function(i) {
-    var dx =  (Math.cos(i * 2 * Math.PI / 6)) * 0.8 * game.width/2
-    var dy =  (Math.sin(i * 2 * Math.PI / 6)) * 0.8 * game.width/2
-    context.lineTo(dx + game.width/2, dy + game.height/2)
-  })
-  context.fillStyle = 'rgb(90,90,90)'
-  context.fill()
-  context.clip()
-})
-
 game.on('update', function(interval){
 
 })
 
-
 game.on('draw', function(context) {
+  mask.set(context)
   world.draw(context, camera)
   player.draw(context, camera)
-  context.restore()
+  mask.unset(context)
   ring.draw(context)
 })
 

--- a/geo/notch.js
+++ b/geo/notch.js
@@ -1,0 +1,38 @@
+var Geometry = require('../geometry.js')
+
+module.exports = function (opts) {
+  opts = opts || {}
+
+  var height = opts.size * Math.sqrt(3) / 2
+  var outer = height + opts.extent
+  var inner = height
+
+  var o = opts.offset || 1
+  var n = opts.count / 6
+  var i = opts.ind % n
+  
+  var start = 120 - (60 / n) * i - o / 2
+  var end = 120 - (60 / n) * (i + 1) + o / 2
+  
+  return new Geometry({
+    props: {
+      fill: 'red',
+      thickness: 0,
+      type: 'polygon'
+    },
+
+    points: [
+      [inner / Math.tan(start * Math.PI / 180), -inner],
+      [outer / Math.tan(start * Math.PI / 180), -outer],
+      [outer / Math.tan(end * Math.PI / 180), -outer],
+      [inner / Math.tan(end * Math.PI / 180), -inner]
+    ],
+
+    transform: {
+      scale: 1,
+      angle: Math.floor(opts.ind / (opts.count / 6)) * 60,
+      position: opts.position
+    },
+  })
+
+}

--- a/geometry.js
+++ b/geometry.js
@@ -146,13 +146,17 @@ Geometry.prototype.drawChildren = function(context, camera) {
 
 Geometry.prototype.drawSelf = function(context, camera) {
   var points = this.points 
-  points = camera.transform.invert(points)
-  points = points.map(function (xy) {
-    return [xy[0] + camera.game.width/2, xy[1] + 2*camera.game.height/4]
-  })
-  if (this.props.type == 'polygon') this.drawPolygon(context, points, camera.transform.scale())
-  if (this.props.type == 'bezier') this.drawBezier(context, points, camera.transform.scale())
-  if (this.props.type == 'line') this.drawLines(context, points, camera.transform.scale())
+  var scale = 1
+  if (camera) {
+    points = camera.transform.invert(points)
+    points = points.map(function (xy) {
+      return [xy[0] + camera.game.width/2, xy[1] + 2*camera.game.height/4]
+    })
+    scale = camera.transform.scale()
+  }
+  if (this.props.type == 'polygon') this.drawPolygon(context, points, scale)
+  if (this.props.type == 'bezier') this.drawBezier(context, points, scale)
+  if (this.props.type == 'line') this.drawLines(context, points, scale)
 }
 
 Geometry.prototype.draw = function(context, camera, opts) {

--- a/mask.js
+++ b/mask.js
@@ -1,0 +1,28 @@
+var _ = require('lodash')
+
+module.exports = Mask
+
+function Mask(opts) {
+  this.size = opts.size
+  this.position = opts.position
+  this.fill = opts.fill || 'rgb(90,90,90)'
+}
+
+Mask.prototype.set = function(context) {
+  var self = this
+  context.save()
+  context.beginPath()
+  context.moveTo(0, 0)
+  _.range(7).map(function(i) {
+    var dx =  (Math.cos(i * 2 * Math.PI / 6)) * self.size
+    var dy =  (Math.sin(i * 2 * Math.PI / 6)) * self.size
+    context.lineTo(dx + self.position[0], dy + self.position[1])
+  })
+  context.fillStyle = self.fill
+  context.fill()
+  context.clip()
+}
+
+Mask.prototype.unset = function(context) {
+  context.restore()
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "crtrdg-keyboard": "0.0.2",
     "crtrdg-mouse": "~0.0.1",
     "crtrdg-player": "0.0.1",
+    "d3-color": "^0.2.7",
     "inherits": "~2.0.0",
     "lodash": "^3.10.1",
     "mathjs": "^2.4.0",

--- a/ring.js
+++ b/ring.js
@@ -1,0 +1,34 @@
+var _ = require('lodash')
+var inherits = require('inherits')
+var notch = require('./geo/notch.js')
+var Entity = require('crtrdg-entity')
+
+module.exports = Ring;
+inherits(Ring, Entity);
+
+function Ring(opts){
+
+  var fill = opts.fill
+  var gap = opts.gap || 0
+  var count = opts.count || 30
+  var extent = opts.extent || 20
+  var size = opts.size || 50
+  var position = opts.position || [size/2, size/2]
+
+  this.notches = _.range(count).map(function (ind) {
+    return notch({size: size, extent: extent, ind: ind, count: count, gap: gap, position: position})
+  })
+
+}
+
+Ring.prototype.draw = function(context) {
+  this.notches.forEach( function(notch) {
+    notch.draw(context)
+  })
+}
+
+Ring.prototype.update = function(colors) {
+  this.notches.forEach( function(notch, i) {
+    notch.props.fill = colors[i]
+  })
+}


### PR DESCRIPTION
This PR adds the ability to add one or more `ring` elements made of colored wedges around the core game area. I've also introduced a `mask`, which lets us clip the core game area within a hexagon, and put the ring around it. Although we're starting to get into components here that are rather specific to hexaworld, I tried to at least keep the specification of both `ring` and `mask` reasonably flexible.
