### PR TITLE
Use pointy-top for mask and ring

### DIFF
--- a/game.js
+++ b/game.js
@@ -38,7 +38,7 @@ var ring = new Ring({
   size: 0.82 * game.width/2,
   position: [game.width/2, game.width/2],
   extent: 0.1 * game.width/2,
-  count: 30,
+  count: 6,
   offset: 3
 })
 

--- a/geo/cap.js
+++ b/geo/cap.js
@@ -1,3 +1,4 @@
+var transform = require('../transform.js')
 var Geometry = require('../geometry.js')
 
 module.exports = function (opts) {
@@ -9,10 +10,10 @@ module.exports = function (opts) {
 
   var o = opts.offset || 1
   var n = opts.count
-  var i = opts.ind
-  
-  var start = 120 - (60 / n) * i - o / 2
-  var end = 120 - (60 / n) * (i + 1) + o / 2
+  var t = transform({angle: -(2 * (60 / n)  - o)})
+
+  var start = 120
+  var end = 120 - (60 / n) + o / 2
   
   return new Geometry({
     props: {
@@ -23,10 +24,12 @@ module.exports = function (opts) {
     },
 
     points: [
-      [inner / Math.tan(start * Math.PI / 180), -inner],
+      t.apply([[outer / Math.tan(end * Math.PI / 180), -outer]])[0],
       [outer / Math.tan(start * Math.PI / 180), -outer],
       [outer / Math.tan(end * Math.PI / 180), -outer],
-      [inner / Math.tan(end * Math.PI / 180), -inner]
+      [inner / Math.tan(end * Math.PI / 180), -inner],
+      [inner / Math.tan(start * Math.PI / 180), -inner],
+      t.apply([[inner / Math.tan(end * Math.PI / 180), -inner]])[0]
     ],
 
     transform: {

--- a/geo/notch.js
+++ b/geo/notch.js
@@ -31,7 +31,7 @@ module.exports = function (opts) {
 
     transform: {
       scale: 1,
-      angle: Math.floor(opts.ind / (opts.count / 6)) * 60,
+      angle: (Math.floor(opts.ind / (opts.count / 6)) * 60) + 30,
       position: opts.position
     },
   })

--- a/mask.js
+++ b/mask.js
@@ -14,8 +14,8 @@ Mask.prototype.set = function(context) {
   context.beginPath()
   context.moveTo(0, 0)
   _.range(7).map(function(i) {
-    var dx =  (Math.cos(i * 2 * Math.PI / 6)) * self.size
-    var dy =  (Math.sin(i * 2 * Math.PI / 6)) * self.size
+    var dx =  (Math.cos(i * 2 * Math.PI / 6 + Math.PI / 6)) * self.size
+    var dy =  (Math.sin(i * 2 * Math.PI / 6 + Math.PI / 6)) * self.size
     context.lineTo(dx + self.position[0], dy + self.position[1])
   })
   context.fillStyle = self.fill

--- a/ring.js
+++ b/ring.js
@@ -1,6 +1,7 @@
 var _ = require('lodash')
 var inherits = require('inherits')
 var notch = require('./geo/notch.js')
+var cap = require('./geo/cap.js')
 var Entity = require('crtrdg-entity')
 
 module.exports = Ring;
@@ -10,14 +11,37 @@ function Ring(opts){
 
   var fill = opts.fill
   var offset = opts.offset || 0
-  var count = opts.count || 30
+  var count = opts.count || 6
   var extent = opts.extent || 20
   var size = opts.size || 50
   var position = opts.position || [size/2, size/2]
 
-  this.notches = _.range(count).map(function (ind) {
-    return notch({size: size, extent: extent, ind: ind, count: count, offset: offset, position: position})
+  var notches = _.flatten(_.range(6).map(function (side) {
+    return _.range(1, count-1).map(function (ind) {
+      return notch({
+        size: size, 
+        extent: extent, 
+        ind: ind, 
+        count: count, 
+        offset: offset, 
+        angle: (side * 60) + 30,
+        position: position
+      })
+    })
+  }))
+
+  var caps = _.range(6).map(function (side) {
+    return cap({
+      size: size,
+      extent: extent,
+      count: count,
+      offset: offset,
+      angle: (side * 60) + 30,
+      position: position
+    })
   })
+
+  this.notches = notches.concat(caps)
 
 }
 


### PR DESCRIPTION
Minor code change but significant change to functionality. With this, the core game tiles are still flat-topped, but the ring and mask are pointy-top. Based on some UI experimenting, the pointy-top is far better for small vertical screens (e.g. mobile), both for the use of space and the feel of the layout, while still looking fine on large horizontal screens.

But switching to pointy-top throughout didn't work because it's so much more natural to move forward along a path. By using pointy-top only for the mask and ring, we keep the game as is, but now the target "directions" -- e.g. where people might tap -- correspond to the corners of the ring, rather than the edges. 

Thoughts? Will this muck up the projections @sofroniewn (beyond a simple rotation)?
