### PR TITLE
Stop at center

### DIFF
--- a/automove.js
+++ b/automove.js
@@ -1,5 +1,10 @@
 var _ = require('lodash')
+var inherits = require('inherits')
 var transform = require('./transform.js')
+var Fixmove = require('./fixmove.js')
+
+module.exports = Automove
+inherits(Automove, Fixmove)
 
 function Automove(data) {
   if (!data) data = {}
@@ -54,33 +59,3 @@ Automove.prototype.reset = function() {
     self.active[i] = false
   })
 }
-
-Automove.prototype.delta = function(current, target) {
-  var dist = current.distance(target)
-
-  var speed = this.speed
-  var velocity = {position: 1, angle: 1}
-  var diff = current.difference(target)
-
-  if (dist.position > speed.position) {
-    diff.position[0] = diff.position[0] / dist.position
-    diff.position[1] = diff.position[1] / dist.position
-    velocity.position = speed.position
-    if (dist.angle > speed.angle) velocity.position = speed.angle * dist.position / dist.angle
-  }
-
-  if (dist.angle > speed.angle) {
-    diff.angle = diff.angle / dist.angle
-    velocity.angle = speed.angle
-  }
-
-  return {
-    position: [
-      diff.position[0] * velocity.position, 
-      diff.position[1] * velocity.position
-    ], 
-    angle: diff.angle * velocity.angle
-  }
-}
-
-module.exports = Automove

--- a/automove.js
+++ b/automove.js
@@ -34,11 +34,15 @@ Automove.prototype.compute = function(keys, current, offset) {
 
   if (!self.tracking) {
     self.target = self.seek(current, 0)
-    var pressed = self.keymap.map(function (k) {return k in keys})
-    if (!_.any(pressed)) self.reset()
+    if (!self.keypress(keys)) self.reset()
   } 
 
   return self.delta(current, self.target)
+}
+
+Automove.prototype.keypress = function(keys) {
+  var pressed = this.keymap.map(function (k) {return k in keys})
+  return _.any(pressed)
 }
 
 Automove.prototype.seek = function (current, heading, offset) {

--- a/fixmove.js
+++ b/fixmove.js
@@ -1,0 +1,41 @@
+var _ = require('lodash')
+var transform = require('./transform.js')
+
+function Fixmove(data) {
+  if (!data) data = {}
+  this.speed = data.speed || {position: 1, angle: 10}
+}
+
+Fixmove.prototype.compute = function(current, target) {
+  return this.delta(current, target)
+}
+
+Fixmove.prototype.delta = function(current, target) {
+  var dist = current.distance(target)
+
+  var speed = this.speed
+  var velocity = {position: 1, angle: 1}
+  var diff = current.difference(target)
+
+  if (dist.position > speed.position) {
+    diff.position[0] = diff.position[0] / dist.position
+    diff.position[1] = diff.position[1] / dist.position
+    velocity.position = speed.position
+    if (dist.angle > speed.angle) velocity.position = speed.angle * dist.position / dist.angle
+  }
+
+  if (dist.angle > speed.angle) {
+    diff.angle = diff.angle / dist.angle
+    velocity.angle = speed.angle
+  }
+
+  return {
+    position: [
+      diff.position[0] * velocity.position, 
+      diff.position[1] * velocity.position
+    ], 
+    angle: diff.angle * velocity.angle
+  }
+}
+
+module.exports = Fixmove

--- a/player.js
+++ b/player.js
@@ -49,20 +49,23 @@ Player.prototype.move = function(keyboard, world) {
   var current = self.geometry.transform
   var tile = world.tiles[world.locate(self.position())]
   var inside =  tile.children[0].contains(current.position())
-
+  var keys = keyboard.keysDown
 
   var delta
   if (inside) {
-    if (self.movement.tile.keypress(keyboard.keysDown)) self.waiting = false
+    if (self.movement.tile.keypress(keys)) self.waiting = false
     if (self.waiting) {
-      delta = self.movement.center.compute(current, {position: [tile.transform.position()[0], tile.transform.position()[1]]})
+      var center = {
+        position: [tile.transform.position()[0], tile.transform.position()[1]]
+      }
+      delta = self.movement.center.compute(current, center)
     } else {
-      delta = self.movement.tile.compute(keyboard.keysDown, current, tile.transform)
+      delta = self.movement.tile.compute(keys, current, tile.transform)
     }
   } else {
     self.waiting = true
     self.movement.tile.reset()
-    delta = self.movement.path.compute(keyboard.keysDown, current)
+    delta = self.movement.path.compute(keys, current)
   }
 
   self.geometry.update(delta)

--- a/player.js
+++ b/player.js
@@ -53,15 +53,15 @@ Player.prototype.move = function(keyboard, world) {
 
   var delta
   if (inside) {
-    var keysDown = keyboard.keysDown
-    if (self.movement.tile.keypress(keysDown)) self.waiting = false
+    if (self.movement.tile.keypress(keyboard.keysDown)) self.waiting = false
     if (self.waiting) {
       delta = self.movement.center.compute(current, {position: [tile.transform.position()[0], tile.transform.position()[1]]})
     } else {
-      delta = self.movement.tile.compute(keysDown, current, tile.transform)
+      delta = self.movement.tile.compute(keyboard.keysDown, current, tile.transform)
     }
   } else {
     self.waiting = true
+    self.movement.tile.reset()
     delta = self.movement.path.compute(keyboard.keysDown, current)
   }
 

--- a/player.js
+++ b/player.js
@@ -50,7 +50,7 @@ Player.prototype.move = function(keyboard, world) {
   var tile = world.tiles[world.locate(self.position())]
   var inside =  tile.children[0].contains(current.position())
 
-  if (_.any(keyboard.keysDown)) self.waiting = false
+  if (self.movement.tile.keypress(keyboard.keysDown)) self.waiting = false
 
   var delta
   if (inside) {

--- a/player.js
+++ b/player.js
@@ -50,14 +50,15 @@ Player.prototype.move = function(keyboard, world) {
   var tile = world.tiles[world.locate(self.position())]
   var inside =  tile.children[0].contains(current.position())
 
-  if (self.movement.tile.keypress(keyboard.keysDown)) self.waiting = false
 
   var delta
   if (inside) {
+    var keysDown = keyboard.keysDown
+    if (self.movement.tile.keypress(keysDown)) self.waiting = false
     if (self.waiting) {
       delta = self.movement.center.compute(current, {position: [tile.transform.position()[0], tile.transform.position()[1]]})
     } else {
-      delta = self.movement.tile.compute(keyboard.keysDown, current, tile.transform)
+      delta = self.movement.tile.compute(keysDown, current, tile.transform)
     }
   } else {
     self.waiting = true

--- a/world.js
+++ b/world.js
@@ -22,7 +22,7 @@ function World(opts) {
         fill: '#64FF00', 
         stroke: 'white', 
         thickness: 0.5, 
-        scale: 0.075
+        scale: 0.08
       })]
     }),
     tile({
@@ -33,7 +33,7 @@ function World(opts) {
         fill: '#00C3EE', 
         stroke: 'white', 
         thickness: 0.5, 
-        scale: 0.075
+        scale: 0.08
       })]
     }),
     tile({
@@ -49,7 +49,7 @@ function World(opts) {
         fill: '#FF8900', 
         stroke: 'white', 
         thickness: 0.5, 
-        scale: 0.075
+        scale: 0.08
       })]
     }),
     tile({
@@ -80,7 +80,7 @@ function World(opts) {
         fill: '#FF5050', 
         stroke: 'white', 
         thickness: 0.5, 
-        scale: 0.075
+        scale: 0.08
       })]      
     })
   ]


### PR DESCRIPTION
This PR changes the movement behavior so that the player stops at the center of each choice point, to give time to make a choice, as suggested by @mathisonian .

Prior to this change, because the player would move until hitting a wall, the player would also "stop" at the choice point, except awkwardly, up against the wall, instead of in the center. With this change it feels strictly better, though there's certainly further tweaking we might want to do.

cc @sofroniewn 
