### PR TITLE
Cues

### DIFF
--- a/game.js
+++ b/game.js
@@ -83,7 +83,7 @@ ring.on('update', function(interval) {
   worldAngle = worldAngle - 90
   if (worldAngle < 0) worldAngle += 360
   var w = Math.min(60/r*(Math.sqrt(3)/2)/2, 360)
-  var c = color.hsl(100, 0.5, Math.max(1 - Math.max(r/5 - 0.25, 0) - 0.35, 0))
+  var c = color.hsl(100, 0.5, Math.max(1 - Math.max(r/1.5 - 0.25, 0) - 0.35, 0))
   //var c = '#64FF00'
 
   console.log(a)
@@ -93,10 +93,10 @@ ring.on('update', function(interval) {
     angle = (-worldAngle + a +  (i*360/30))
     if (angle > 180) angle = 360 - angle
   
-  if (Math.abs(angle) <= w/2 & r > .01 & r < 0.75*5) {
+  if (Math.abs(angle) <= w/2 & r > .01 & r < 0.75*1.5) {
     return c.toString()
   } else if (r <= .01) {
-    c = color.hsl(100, 0.5, Math.max(1 - Math.max(.01/5 - 0.25, 0) - 0.35, 0))
+    c = color.hsl(100, 0.5, Math.max(1 - Math.max(.01/1.5 - 0.25, 0) - 0.35, 0))
     return c.toString()
     } else {
     return 'rgb(55,55,55)'

--- a/game.js
+++ b/game.js
@@ -1,5 +1,4 @@
 var _ = require('lodash')
-var color = require('d3-color')
 var Game = require('crtrdg-gameloop');
 var Keyboard = require('crtrdg-keyboard');
 var Mouse = require('crtrdg-mouse');
@@ -65,7 +64,6 @@ keyboard.on('keydown', function(keyCode){
 });
 
 player.on('update', function(interval) {
-  //this.move(keyboard, world)
   this.move(keyboard, world)
 });
 
@@ -80,40 +78,7 @@ camera.on('update', function(interval) {
 })
 
 ring.on('update', function(interval) {
-  //this.update(colors)
-  //  var colors = _.range(30).map(function (i) {
-//    var r = Math.sqrt(Math.pow(player.position()[0], 2) + Math.pow(player.position()[1], 2)) / 100
-//    var c = color.hsl(player.angle(), 0.5, Math.max(1 - Math.max(r - 0.25, 0) - 0.35, 0))
-//    return c.toString()
-//  })
-  var r = Math.sqrt(Math.pow(player.position()[0], 2) + Math.pow(player.position()[1], 2)) / 100
-  var worldAngle = 180/Math.PI*Math.atan2(player.position()[1],player.position()[0])
-  var a = player.angle() % 360
-  if (a < 0) a += 360
-  if (worldAngle < 0) worldAngle += 360
-  worldAngle = worldAngle - 90
-  if (worldAngle < 0) worldAngle += 360
-  var w = Math.min(60/r*(Math.sqrt(3)/2)/2, 360)
-  var c = color.hsl(100, 0.5, Math.max(1 - Math.max(r/1.5 - 0.25, 0) - 0.35, 0))
-  //var c = '#64FF00'
-
-  console.log(a)
-  console.log(worldAngle)
-
-  var colors = _.range(30).map(function (i) {
-    angle = (-worldAngle + a +  (i*360/30))
-    if (angle > 180) angle = 360 - angle
-  
-  if (Math.abs(angle) <= w/2 & r > .01 & r < 0.75*1.5) {
-    return c.toString()
-  } else if (r <= .01) {
-    c = color.hsl(100, 0.5, Math.max(1 - Math.max(.01/1.5 - 0.25, 0) - 0.35, 0))
-    return c.toString()
-    } else {
-    return 'rgb(55,55,55)'
-  }
-  })
-  this.update(colors)
+  this.update(player, world)
 })
 
 world.on('location', function(msg) {

--- a/game.js
+++ b/game.js
@@ -70,6 +70,39 @@ camera.on('update', function(interval) {
 
 ring.on('update', function(interval) {
   //this.update(colors)
+  //  var colors = _.range(30).map(function (i) {
+//    var r = Math.sqrt(Math.pow(player.position()[0], 2) + Math.pow(player.position()[1], 2)) / 100
+//    var c = color.hsl(player.angle(), 0.5, Math.max(1 - Math.max(r - 0.25, 0) - 0.35, 0))
+//    return c.toString()
+//  })
+  var r = Math.sqrt(Math.pow(player.position()[0], 2) + Math.pow(player.position()[1], 2)) / 100
+  var worldAngle = 180/Math.PI*Math.atan2(player.position()[1],player.position()[0])
+  var a = player.angle() % 360
+  if (a < 0) a += 360
+  if (worldAngle < 0) worldAngle += 360
+  worldAngle = worldAngle - 90
+  if (worldAngle < 0) worldAngle += 360
+  var w = Math.min(60/r*(Math.sqrt(3)/2)/2, 360)
+  var c = color.hsl(100, 0.5, Math.max(1 - Math.max(r/5 - 0.25, 0) - 0.35, 0))
+  //var c = '#64FF00'
+
+  console.log(a)
+  console.log(worldAngle)
+
+  var colors = _.range(30).map(function (i) {
+    angle = (-worldAngle + a +  (i*360/30 - 30))
+    if (angle > 180) angle = 360 - angle
+  
+  if (Math.abs(angle) <= w/2 & r > .01 & r < 0.75*5) {
+    return c.toString()
+  } else if (r <= .01) {
+    c = color.hsl(100, 0.5, Math.max(1 - Math.max(.01/5 - 0.25, 0) - 0.35, 0))
+    return c.toString()
+    } else {
+    return 'rgb(55,55,55)'
+  }
+  })
+  this.update(colors)
 })
 
 world.on('location', function(msg) {

--- a/game.js
+++ b/game.js
@@ -90,7 +90,7 @@ ring.on('update', function(interval) {
   console.log(worldAngle)
 
   var colors = _.range(30).map(function (i) {
-    angle = (-worldAngle + a +  (i*360/30 - 30))
+    angle = (-worldAngle + a +  (i*360/30))
     if (angle > 180) angle = 360 - angle
   
   if (Math.abs(angle) <= w/2 & r > .01 & r < 0.75*5) {

--- a/geo/block.js
+++ b/geo/block.js
@@ -10,7 +10,8 @@ module.exports = function (opts) {
       fill: 'rgb(55,55,55)',
       stroke: 'rgb(55,55,55)',
       thickness: 0,
-      type: 'polygon'
+      type: 'polygon',
+      obstacle: true
     },
 
     points: [
@@ -25,9 +26,7 @@ module.exports = function (opts) {
       angle: opts.angle || 0
     },
 
-    children: opts.children, 
-
-    obstacle: true
+    children: opts.children
   })
 
 }

--- a/geo/circle.js
+++ b/geo/circle.js
@@ -10,7 +10,8 @@ module.exports = function (opts) {
       stroke: opts.stroke || '#7D7D7D',
       thickness: opts.thickness || 1,
       shadow: opts.shadow || {},
-      type: 'bezier'
+      type: 'bezier',
+      cue: true
     },
 
     points: [
@@ -26,9 +27,7 @@ module.exports = function (opts) {
       angle: opts.angle || 0
     },
 
-    children: opts.children,
-
-    trigger: true
+    children: opts.children
   })
 
 } 

--- a/geo/wedge.js
+++ b/geo/wedge.js
@@ -10,7 +10,8 @@ module.exports = function (opts) {
       fill: 'rgb(55,55,55)',
       stroke: 'rgb(55,55,55)',
       thickness: 0,
-      type: 'polygon'
+      type: 'polygon',
+      obstacle: true
     },
 
     points: [
@@ -25,9 +26,7 @@ module.exports = function (opts) {
       angle: opts.angle || 0
     },
 
-    children: opts.children,
-
-    obstacle: true
+    children: opts.children
   })
 
 }

--- a/geometry.js
+++ b/geometry.js
@@ -8,7 +8,6 @@ function Geometry(data) {
   if (!data.points) throw new Error('Must provide points')
   this.props = data.props
   this.points = data.points
-  this.obstacle = data.obstacle
   if (_.isArray(data.children)) {
     this.children = data.children
   } else {

--- a/ring.js
+++ b/ring.js
@@ -83,12 +83,13 @@ Ring.prototype.project = function(origin, targets) {
 
     var interp = Math.max(1 - radius, 0.5)
     var fill = color.interpolateHsl('rgb(55,55,55)', target.color)(interp)
-
+    
     return {angle: angle, radius: radius, fill: fill}
   })
 }
 
 Ring.prototype.update = function(player, world) {
+  self = this
 
   var projections = this.project(player.geometry.transform, world.cues())
 
@@ -102,9 +103,8 @@ Ring.prototype.update = function(player, world) {
     }
   }
 
-  length = this.notches.length
   var colors = this.notches.map( function(notch, i) {
-    var fills = projections.map( function(p) {return discretize(i, p, 30)})
+    var fills = projections.map( function(p) {return discretize(i, p, self.notches.length)})
     if (!_.any(fills)) return 'rgb(55,55,55)'
     return _.min(_.remove(fills), function(f) {return f.radius}).fill.toString()
   })

--- a/ring.js
+++ b/ring.js
@@ -79,7 +79,7 @@ Ring.prototype.project = function(origin, targets) {
     angle += offset
 
     var interp = Math.max(1 - radius, 0)
-    var fill = color.interpolateRgb('rgb(55,55,55)', target.color)(interp)
+    var fill = color.interpolateLab('rgb(55,55,55)', target.color)(interp)
 
     return {angle: angle, radius: radius, fill: fill}
   })

--- a/ring.js
+++ b/ring.js
@@ -16,6 +16,10 @@ function Ring(opts){
   var extent = opts.extent || 20
   var size = opts.size || 50
   var position = opts.position || [size/2, size/2]
+  
+  this.maxangle = opts.maxangle || 110
+  this.maxdistance = opts.maxdistance || 100
+  this.scale = opts.scale || 20
 
   var notches = _.flatten(_.range(6).map(function (side) {
     return _.range(1, count-1).map(function (ind) {
@@ -62,11 +66,13 @@ Ring.prototype.recolor = function(colors) {
 }
 
 Ring.prototype.project = function(origin, targets) {
+  self = this
+
   return targets.map(function (target) {
     var diff = origin.difference(target)
     var dist = origin.distance(target)
 
-    var radius = dist.position / 100
+    var radius = dist.position / self.maxdistance
     var angle = Math.atan2(-diff.position[1], -diff.position[0]) * 180 / Math.PI
 
     if (angle < 0) angle += 360
@@ -93,8 +99,6 @@ Ring.prototype.project = function(origin, targets) {
 Ring.prototype.update = function(player, world) {
   self = this
 
-  var maxangle = 110
-
   var projections = this.project(player.geometry.transform, world.cues())
 
   function discretize(i, p, length) {
@@ -102,7 +106,7 @@ Ring.prototype.update = function(player, world) {
     if (tmp > 180) tmp = 360 - tmp
     if (tmp < -180) tmp = 360 + tmp
     
-    if (Math.abs(tmp) <= Math.min(40/p.radius * (Math.sqrt(3)/2)/2, maxangle)/2 & p.radius < 1) {
+    if (Math.abs(tmp) <= Math.min(self.scale/p.radius, self.maxangle)/2 & p.radius < 1) {
       return {radius: p.radius, fill: color.rgb(p.fill)}
     }
   }

--- a/ring.js
+++ b/ring.js
@@ -84,12 +84,16 @@ Ring.prototype.project = function(origin, targets) {
     var interp = Math.max(1 - radius, 0.5)
     var fill = color.interpolateHsl('rgb(55,55,55)', target.color)(interp)
     
+    if (radius < .01) angle = 0
+
     return {angle: angle, radius: radius, fill: fill}
   })
 }
 
 Ring.prototype.update = function(player, world) {
   self = this
+
+  var maxangle = 110
 
   var projections = this.project(player.geometry.transform, world.cues())
 
@@ -98,7 +102,7 @@ Ring.prototype.update = function(player, world) {
     if (tmp > 180) tmp = 360 - tmp
     if (tmp < -180) tmp = 360 + tmp
     
-    if (Math.abs(tmp) <= Math.min(60/p.radius * (Math.sqrt(3)/2)/2, 360)/2 & p.radius < 1) {
+    if (Math.abs(tmp) <= Math.min(60/p.radius * (Math.sqrt(3)/2)/2, maxangle)/2 & p.radius < 1) {
       return {radius: p.radius, fill: color.rgb(p.fill)}
     }
   }

--- a/ring.js
+++ b/ring.js
@@ -102,7 +102,7 @@ Ring.prototype.update = function(player, world) {
     if (tmp > 180) tmp = 360 - tmp
     if (tmp < -180) tmp = 360 + tmp
     
-    if (Math.abs(tmp) <= Math.min(60/p.radius * (Math.sqrt(3)/2)/2, maxangle)/2 & p.radius < 1) {
+    if (Math.abs(tmp) <= Math.min(40/p.radius * (Math.sqrt(3)/2)/2, maxangle)/2 & p.radius < 1) {
       return {radius: p.radius, fill: color.rgb(p.fill)}
     }
   }

--- a/ring.js
+++ b/ring.js
@@ -79,7 +79,7 @@ Ring.prototype.project = function(origin, targets) {
     angle += offset
 
     var interp = Math.max(1 - radius, 0)
-    var fill = color.interpolateLab('rgb(55,55,55)', target.color)(interp)
+    var fill = color.interpolateHsl('rgb(10,10,10)', target.color)(interp)
 
     return {angle: angle, radius: radius, fill: fill}
   })

--- a/ring.js
+++ b/ring.js
@@ -42,13 +42,11 @@ function Ring(opts){
     })
   })
 
+  _.range(6).forEach(function(i) {
+    notches.splice(i*(opts.count-1), 0, caps[i])
+  })
+
   this.notches = notches
-  this.notches.splice(0, 0, caps[0])
-  this.notches.splice(5, 0, caps[1])
-  this.notches.splice(10, 0, caps[2])
-  this.notches.splice(15, 0, caps[3])
-  this.notches.splice(20, 0, caps[4])
-  this.notches.splice(25, 0, caps[5])
 }
 
 Ring.prototype.draw = function(context) {
@@ -58,7 +56,7 @@ Ring.prototype.draw = function(context) {
 }
 
 Ring.prototype.recolor = function(colors) {
-  this.notches.forEach( function(notch, i) {
+  this.notches.forEach(function(notch, i) {
     notch.props.fill = colors[i]
   })
 }

--- a/ring.js
+++ b/ring.js
@@ -41,8 +41,6 @@ function Ring(opts){
     })
   })
 
-  
-//  this.notches = notches.concat(caps)
   this.notches = notches
   this.notches.splice(0, 0, caps[0])
   this.notches.splice(5, 0, caps[1])
@@ -58,8 +56,44 @@ Ring.prototype.draw = function(context) {
   })
 }
 
-Ring.prototype.update = function(colors) {
+Ring.prototype.recolor = function(colors) {
   this.notches.forEach( function(notch, i) {
     notch.props.fill = colors[i]
   })
+}
+
+Ring.prototype.project = function(origin, cues) {
+  return cues.map(function (cue) {
+    var diff = origin.difference(cue)
+    var dist = origin.distance(cue)
+
+    var radius = dist.position / 100
+    var angle = Math.atan2(-diff.position[1], -diff.position[0]) * 180 / Math.PI
+
+    if (angle < 90) angle += 360
+    angle = 90 - angle
+
+    var offset = origin.angle() % 360
+    if (offset < 0) offset += 360
+    angle += offset
+
+    return {angle: angle, radius: radius, color: cue.color}
+  })
+}
+
+Ring.prototype.update = function(player, world) {
+  var projections = this.project(player.geometry.transform, world.cues())
+  var proj = projections[1]
+
+  var colors = this.notches.map( function(notch, i) {
+    var tmp = proj.angle + i * 360/30
+    if (tmp > 180) tmp = 360 - tmp
+
+    if (Math.abs(tmp) <= Math.min(60/proj.radius * (Math.sqrt(3)/2)/2, 360)/2 & proj.radius < 1.125) {
+      return proj.color.toString()
+    } else {
+      return 'rgb(55,55,55)'
+    }
+  })
+  this.recolor(colors)
 }

--- a/ring.js
+++ b/ring.js
@@ -62,10 +62,10 @@ Ring.prototype.recolor = function(colors) {
   })
 }
 
-Ring.prototype.project = function(origin, cues) {
-  return cues.map(function (cue) {
-    var diff = origin.difference(cue)
-    var dist = origin.distance(cue)
+Ring.prototype.project = function(origin, targets) {
+  return targets.map(function (target) {
+    var diff = origin.difference(target)
+    var dist = origin.distance(target)
 
     var radius = dist.position / 100
     var angle = Math.atan2(-diff.position[1], -diff.position[0]) * 180 / Math.PI
@@ -77,15 +77,15 @@ Ring.prototype.project = function(origin, cues) {
     if (offset < 0) offset += 360
     angle += offset
 
-    return {angle: angle, radius: radius, color: cue.color}
+    return {angle: angle, radius: radius, color: target.color}
   })
 }
 
 Ring.prototype.update = function(player, world) {
   var projections = this.project(player.geometry.transform, world.cues())
-  var proj = projections[1]
 
   var colors = this.notches.map( function(notch, i) {
+    var proj = _.min(projections, function (p) {return p.radius})
     var tmp = proj.angle + i * 360/30
     if (tmp > 180) tmp = 360 - tmp
 

--- a/ring.js
+++ b/ring.js
@@ -41,8 +41,15 @@ function Ring(opts){
     })
   })
 
-  this.notches = notches.concat(caps)
-
+  
+//  this.notches = notches.concat(caps)
+  this.notches = notches
+  this.notches.splice(0, 0, caps[0])
+  this.notches.splice(5, 0, caps[1])
+  this.notches.splice(10, 0, caps[2])
+  this.notches.splice(15, 0, caps[3])
+  this.notches.splice(20, 0, caps[4])
+  this.notches.splice(25, 0, caps[5])
 }
 
 Ring.prototype.draw = function(context) {

--- a/world.js
+++ b/world.js
@@ -1,5 +1,6 @@
 var _ = require('lodash')
 var inherits = require('inherits')
+var color = require('d3-color')
 var tile = require('./geo/tile.js')
 var hex = require('./geo/hex.js')
 var circle = require('./geo/circle.js')
@@ -108,6 +109,19 @@ World.prototype.locate = function(point) {
   var ind = _.indexOf(status, true)
   if (ind === -1) throw Error('Cannot find player in a tile')
   return ind
+}
+
+World.prototype.cues = function() {
+  var cues = []
+  this.tiles.forEach(function (tile) {
+    if (tile.children.length > 0) {
+      var cue = {
+        position: tile.transform.position(), 
+        color: tile.children[tile.children.length - 1].props.fill}
+      cues.push(cue)
+    }
+  })
+  return cues
 }
 
 World.prototype.intersects = function(geometry) {

--- a/world.js
+++ b/world.js
@@ -55,7 +55,7 @@ function World(opts) {
     tile({
       position: [1, -1],
       scale: 50,
-      paths: [2]
+      paths: [2, 3]
     }),
     tile({
       position: [1, 0],
@@ -65,7 +65,23 @@ function World(opts) {
     tile({
       position: [0, -1],
       scale: 50,
-      paths: [1, 5]
+      paths: [1, 3, 5]
+    }),
+    tile({
+      position: [0, -2],
+      scale: 50,
+      paths: [0, 5]
+    }),
+    tile({
+      position: [1, -2],
+      scale: 50,
+      paths: [0, 2],
+      children: [circle({
+        fill: '#FF0000', 
+        stroke: 'white', 
+        thickness: 0.5, 
+        scale: 0.075
+      })]      
     })
   ]
 

--- a/world.js
+++ b/world.js
@@ -114,12 +114,8 @@ World.prototype.locate = function(point) {
 World.prototype.cues = function() {
   var cues = []
   this.tiles.forEach(function (tile) {
-    if (tile.children.length > 0) {
-      var cue = {
-        position: tile.transform.position(), 
-        color: tile.children[tile.children.length - 1].props.fill}
-      cues.push(cue)
-    }
+    var cue = _.find(tile.children, function(child) {return child.props.cue})
+    if (cue) cues.push({position: tile.transform.position(), color: cue.props.fill})
   })
   return cues
 }
@@ -129,7 +125,7 @@ World.prototype.intersects = function(geometry) {
   var results = []
   this.tiles.forEach(function (tile) {
     tile.children.forEach(function (child) {
-      if (child.obstacle) {
+      if (child.props.obstacle) {
         var collision = child.intersects(geometry)
         if (collision) results.push(collision)
       }

--- a/world.js
+++ b/world.js
@@ -115,7 +115,10 @@ World.prototype.cues = function() {
   var cues = []
   this.tiles.forEach(function (tile) {
     var cue = _.find(tile.children, function(child) {return child.props.cue})
-    if (cue) cues.push({position: tile.transform.position(), color: cue.props.fill})
+    if (cue) cues.push({
+      position: tile.transform.position(), 
+      color: cue.props.fill
+    })
   })
   return cues
 }


### PR DESCRIPTION
This PR adds support for "cues" either distal or global represented as colors projected onto the ring. I refactored @sofroniewn's initial implementation to organize the various steps. Most of the logic is built into `ring`, where I felt it probably belongs, but I added a helper function to `world` that returns all tiles with objects marked as a `cue`, which can now be added to a geometry's `props` (along with `obstacle`).

The "base" color, currently dark gray, shows up in just two places, and it should more or less work with a different base color (e.g. in the light color scheme) because the blending uses interpolation from `d3-color`.

I tried to leave room for alternate combination / blocking schemes, it's essentially all baked into `Ring.update`. After computing the projections, we get back a set of color fills (one per cue per notch), and then combine them in whatever way we want.

@sofroniewn in cleaning all this up I surely introduced an error or two, I think the behavior is very close to what you had, except maybe the handling when you're on top of a cue, if you want to try and fix that.

![color](https://cloud.githubusercontent.com/assets/3387500/11164646/623082a0-8ac4-11e5-95e7-74709845a2f4.gif)
