### PR TITLE
"Conlen controls"

### DIFF
--- a/automove.js
+++ b/automove.js
@@ -12,9 +12,8 @@ function Automove(data) {
   this.keymap = data.keymap || ['Q', 'W', 'E', 'A', 'S', 'D']
   this.heading = data.heading || [-60, 0, 60, -120, -180, 120]
   this.shift = data.shift || [1, 1, 1, 1, 1, 1]
-  this.auto = data.auto
   this.active = _.fill(Array(this.keymap.length), false)
-  this.last = _.fill(Array(this.keymap.length), false)
+  this.pressed = _.fill(Array(this.keymap.length), false)
   this.tracking = false
 }
 
@@ -23,9 +22,10 @@ Automove.prototype.compute = function(keys, current, offset) {
 
   self.keymap.forEach( function(key, i) {
     if (key in keys & !(_.any(self.active))) {
-      self.resetlast()
+      self.reset()
+      self.clear()
       self.active[i] = true
-      self.last[i] = true
+      self.pressed[i] = true
       self.tracking = true
       self.target = self.seek(current, self.heading[i], self.shift[i], offset)
     }
@@ -38,7 +38,7 @@ Automove.prototype.compute = function(keys, current, offset) {
 
   if (!self.tracking) {
     var shift = 1
-    if (!self.auto & _.any(self.last)) shift = self.shift[_.findIndex(self.last)]
+    if (_.any(self.pressed)) shift = self.shift[_.findIndex(self.pressed)]
     self.target = self.seek(current, 0, shift)
     if (!self.keypress(keys)) self.reset()
   } 
@@ -47,8 +47,8 @@ Automove.prototype.compute = function(keys, current, offset) {
 }
 
 Automove.prototype.keypress = function(keys) {
-  var pressed = this.keymap.map(function (k) {return k in keys})
-  return _.any(pressed)
+  var down = this.keymap.map(function (k) {return k in keys})
+  return _.any(down)
 }
 
 Automove.prototype.seek = function (current, heading, shift, offset) {
@@ -64,15 +64,9 @@ Automove.prototype.seek = function (current, heading, shift, offset) {
 }
 
 Automove.prototype.reset = function() {
-  var self = this
-  self.keymap.forEach(function (k, i) {
-    self.active[i] = false
-  })
+  this.active = this.active.map( function() {return false})
 }
 
-Automove.prototype.resetlast = function() {
-  var self = this
-  self.keymap.forEach(function (k, i) {
-    self.last[i] = false
-  })
+Automove.prototype.clear = function() {
+  this.pressed = this.pressed.map( function() {return false})
 }

--- a/automove.js
+++ b/automove.js
@@ -55,8 +55,8 @@ Automove.prototype.seek = function (current, heading, shift, offset) {
 
   return {
     position: [
-      shift * Math.sin((current.angle() + heading) * Math.PI / 180) + offset.position[0], 
-      shift * -Math.cos((current.angle() + heading) * Math.PI / 180) + offset.position[1]
+      shift * Math.sin((current.angle + heading) * Math.PI / 180) + offset.position[0], 
+      shift * -Math.cos((current.angle + heading) * Math.PI / 180) + offset.position[1]
     ], 
     angle: current.angle + heading
   }

--- a/automove.js
+++ b/automove.js
@@ -11,8 +11,10 @@ function Automove(data) {
   this.speed = data.speed || {position: 1, angle: 10}
   this.keymap = data.keymap || ['Q', 'W', 'E', 'A', 'S', 'D']
   this.heading = data.heading || [-60, 0, 60, -120, -180, 120]
-  this.shift = data.shift || 1
-  this.active = [false, false, false, false, false, false]
+  this.shift = data.shift || [1, 1, 1, 1, 1, 1]
+  this.auto = data.auto
+  this.active = _.fill(Array(this.keymap.length), false)
+  this.last = _.fill(Array(this.keymap.length), false)
   this.tracking = false
 }
 
@@ -21,9 +23,11 @@ Automove.prototype.compute = function(keys, current, offset) {
 
   self.keymap.forEach( function(key, i) {
     if (key in keys & !(_.any(self.active))) {
+      self.resetlast()
       self.active[i] = true
-      self.target = self.seek(current, self.heading[i], offset)
+      self.last[i] = true
       self.tracking = true
+      self.target = self.seek(current, self.heading[i], self.shift[i], offset)
     }
   })
 
@@ -33,7 +37,9 @@ Automove.prototype.compute = function(keys, current, offset) {
   } 
 
   if (!self.tracking) {
-    self.target = self.seek(current, 0)
+    var shift = 1
+    if (!self.auto & _.any(self.last)) shift = self.shift[_.findIndex(self.last)]
+    self.target = self.seek(current, 0, shift)
     if (!self.keypress(keys)) self.reset()
   } 
 
@@ -45,13 +51,13 @@ Automove.prototype.keypress = function(keys) {
   return _.any(pressed)
 }
 
-Automove.prototype.seek = function (current, heading, offset) {
+Automove.prototype.seek = function (current, heading, shift, offset) {
   if (!offset) offset = current
 
   return {
     position: [
-      this.shift * Math.sin((current.angle() + heading) * Math.PI / 180) + offset.position()[0], 
-      this.shift * -Math.cos((current.angle() + heading) * Math.PI / 180) + offset.position()[1]
+      shift * Math.sin((current.angle() + heading) * Math.PI / 180) + offset.position()[0], 
+      shift * -Math.cos((current.angle() + heading) * Math.PI / 180) + offset.position()[1]
     ], 
     angle: current.angle() + heading
   }
@@ -61,5 +67,12 @@ Automove.prototype.reset = function() {
   var self = this
   self.keymap.forEach(function (k, i) {
     self.active[i] = false
+  })
+}
+
+Automove.prototype.resetlast = function() {
+  var self = this
+  self.keymap.forEach(function (k, i) {
+    self.last[i] = false
   })
 }

--- a/automove.js
+++ b/automove.js
@@ -37,7 +37,7 @@ Automove.prototype.compute = function(keys, current, offset) {
   } 
 
   if (!self.tracking) {
-    var shift = 1
+    var shift = 2
     if (_.any(self.pressed)) shift = self.shift[_.findIndex(self.pressed)]
     self.target = self.seek(current, 0, shift)
     if (!self.keypress(keys)) self.reset()

--- a/fixmove.js
+++ b/fixmove.js
@@ -21,12 +21,12 @@ Fixmove.prototype.delta = function(current, target) {
     diff.position[0] = diff.position[0] / dist.position
     diff.position[1] = diff.position[1] / dist.position
     velocity.position = speed.position
-    if (dist.angle > speed.angle) velocity.position = speed.angle * dist.position / dist.angle
   }
 
   if (dist.angle > speed.angle) {
     diff.angle = diff.angle / dist.angle
     velocity.angle = speed.angle
+    if (dist.position > speed.position) velocity.angle = speed.position * dist.angle / dist.position
   }
 
   return {

--- a/game.js
+++ b/game.js
@@ -19,7 +19,7 @@ var mouse = new Mouse(game)
 
 var player = new Player({
   scale: 2,
-  speed: {position: 1.25, angle: 8},
+  speed: {position: 1.1, angle: 8},
   friction: 0.9,
   stroke: 'white',
   fill: 'rgb(75,75,75)',
@@ -37,7 +37,7 @@ var ring = new Ring({
   size: 0.82 * game.width/2,
   position: [game.width/2, game.width/2],
   extent: 0.1 * game.width/2,
-  count: 6,
+  count: 8,
   offset: 3
 })
 

--- a/game.js
+++ b/game.js
@@ -19,7 +19,7 @@ var mouse = new Mouse(game)
 
 var player = new Player({
   scale: 2,
-  speed: {position: .75, angle: 8},
+  speed: {position: 1.25, angle: 8},
   friction: 0.9,
   stroke: 'white',
   fill: 'rgb(75,75,75)',

--- a/game.js
+++ b/game.js
@@ -19,7 +19,7 @@ var mouse = new Mouse(game)
 
 var player = new Player({
   scale: 2,
-  speed: {position: 1.1, angle: 8},
+  speed: {position: 1, angle: 8},
   friction: 0.9,
   stroke: 'white',
   fill: 'rgb(75,75,75)',

--- a/player.js
+++ b/player.js
@@ -37,9 +37,9 @@ function Player(opts){
     speed: opts.speed
   })
   this.movement.path = new Automove({
-    keymap: ['A', 'D'], 
-    heading: [-180, 180],
-    shift: [8, 8],
+    keymap: ['A', 'S', 'D'], 
+    heading: [-180, 180, 180],
+    shift: [8, 8, 8],
     speed: opts.speed
   })
   this.collision = new Collision()

--- a/player.js
+++ b/player.js
@@ -31,15 +31,18 @@ function Player(opts){
   this.movement = {}
   this.movement.center = new Fixmove({speed: opts.speed})
   this.movement.tile = new Automove({
-    keymap: ['Q', 'W', 'E', 'A', 'S', 'D'],
-    heading: [-60, 0, 60, -120, -180, 120],
-    shift: 8,
-    speed: opts.speed
+    keymap: ['Q', 'E', 'S', 'W'],
+    heading: [-60, 60, -180, 0],
+    shift: [0, 0, 0, 8],
+    speed: opts.speed,
+    auto: false
   })
   this.movement.path = new Automove({
     keymap: ['S'], 
     heading: [-180],
-    speed: opts.speed
+    shift: [8],
+    speed: opts.speed,
+    auto: true
   })
   this.collision = new Collision()
   this.waiting = true
@@ -67,6 +70,7 @@ Player.prototype.move = function(keyboard, world) {
   } else {
     self.waiting = true
     self.movement.tile.reset()
+    self.movement.tile.resetlast()
     delta = self.movement.path.compute(keys, current)
   }
 

--- a/player.js
+++ b/player.js
@@ -31,9 +31,9 @@ function Player(opts){
   this.movement = {}
   this.movement.center = new Fixmove({speed: opts.speed})
   this.movement.tile = new Automove({
-    keymap: ['A', 'D', 'S', 'W'],
-    heading: [-60, 60, -180, 0],
-    shift: [0, 0, 0, 8],
+    keymap: ['A', 'D', 'W'],
+    heading: [-60, 60, 0],
+    shift: [0, 0, 8],
     speed: opts.speed
   })
   this.movement.path = new Automove({

--- a/player.js
+++ b/player.js
@@ -40,7 +40,7 @@ function Player(opts){
     keymap: ['A', 'D'], 
     heading: [-180, 180],
     shift: [8, 8],
-    speed: opts.speed
+    speed: opts.speed * 1.2
   })
   this.collision = new Collision()
   this.waiting = true

--- a/player.js
+++ b/player.js
@@ -37,9 +37,9 @@ function Player(opts){
     speed: opts.speed
   })
   this.movement.path = new Automove({
-    keymap: ['S'], 
-    heading: [-180],
-    shift: [8],
+    keymap: ['A', 'D'], 
+    heading: [-180, 180],
+    shift: [8, 8],
     speed: opts.speed
   })
   this.collision = new Collision()

--- a/player.js
+++ b/player.js
@@ -31,15 +31,15 @@ function Player(opts){
   this.movement = {}
   this.movement.center = new Fixmove({speed: opts.speed})
   this.movement.tile = new Automove({
-    keymap: ['A', 'D', 'W'],
-    heading: [-60, 60, 0],
-    shift: [0, 0, 8],
+    keymap: ['A', 'D', 'W', '<left>', '<right>', '<up>'],
+    heading: [-60, 60, 0, -60, 60, 0],
+    shift: [0, 0, 8, 0, 0, 8],
     speed: opts.speed
   })
   this.movement.path = new Automove({
-    keymap: ['A', 'D'], 
-    heading: [-180, 180],
-    shift: [8, 8],
+    keymap: ['A', 'D', '<left>', '<right>'], 
+    heading: [-180, 180, -180, 180],
+    shift: [8, 8, 8, 8],
     speed: opts.speed
   })
   this.collision = new Collision()

--- a/player.js
+++ b/player.js
@@ -34,15 +34,13 @@ function Player(opts){
     keymap: ['Q', 'E', 'S', 'W'],
     heading: [-60, 60, -180, 0],
     shift: [0, 0, 0, 8],
-    speed: opts.speed,
-    auto: false
+    speed: opts.speed
   })
   this.movement.path = new Automove({
     keymap: ['S'], 
     heading: [-180],
     shift: [8],
-    speed: opts.speed,
-    auto: true
+    speed: opts.speed
   })
   this.collision = new Collision()
   this.waiting = true
@@ -70,7 +68,6 @@ Player.prototype.move = function(keyboard, world) {
   } else {
     self.waiting = true
     self.movement.tile.reset()
-    self.movement.tile.resetlast()
     delta = self.movement.path.compute(keys, current)
   }
 

--- a/player.js
+++ b/player.js
@@ -36,9 +36,9 @@ function Player(opts){
     speed: opts.speed
   })
   this.movement.path = new Automove({
-    keymap: ['A', 'D', '<left>', '<right>'], 
-    heading: [-180, 180, -180, 180],
-    shift: [8, 8, 8, 8],
+    keymap: ['W', 'S', '<up>', '<down>'], 
+    heading: [0, 0, 0, 0],
+    shift: [1, -1, 1, -1],
     speed: opts.speed
   })
   this.collision = new Collision()
@@ -65,6 +65,8 @@ Player.prototype.move = function(keyboard, world) {
     } else {
       delta = self.movement.tile.compute(keys, current, tile.transform)
     }
+    self.movement.path.reset()
+    self.movement.path.clear()
   } else {
     self.waiting = true
     self.movement.tile.reset()

--- a/player.js
+++ b/player.js
@@ -31,7 +31,7 @@ function Player(opts){
   this.movement = {}
   this.movement.center = new Fixmove({speed: opts.speed})
   this.movement.tile = new Automove({
-    keymap: ['Q', 'E', 'S', 'W'],
+    keymap: ['A', 'D', 'S', 'W'],
     heading: [-60, 60, -180, 0],
     shift: [0, 0, 0, 8],
     speed: opts.speed

--- a/player.js
+++ b/player.js
@@ -40,7 +40,7 @@ function Player(opts){
     keymap: ['A', 'D'], 
     heading: [-180, 180],
     shift: [8, 8],
-    speed: opts.speed * 1.2
+    speed: opts.speed
   })
   this.collision = new Collision()
   this.waiting = true

--- a/player.js
+++ b/player.js
@@ -37,9 +37,9 @@ function Player(opts){
     speed: opts.speed
   })
   this.movement.path = new Automove({
-    keymap: ['A', 'S', 'D'], 
-    heading: [-180, 180, 180],
-    shift: [8, 8, 8],
+    keymap: ['A', 'D'], 
+    heading: [-180, 180],
+    shift: [8, 8],
     speed: opts.speed
   })
   this.collision = new Collision()

--- a/ring.js
+++ b/ring.js
@@ -88,10 +88,10 @@ Ring.prototype.project = function(origin, targets) {
     if (angle < 0) angle += 360
     if (radius < .01) angle = 0
 
-    //var interp = Math.max(1 - radius, 0.5)
-    //var fill = color.interpolateHsl('rgb(55,55,55)', target.color)(interp)
+    var interp = Math.max(1 - radius, 0.5)
+    var fill = color.interpolateHsl('rgb(55,55,55)', target.color)(interp)
 
-    return {angle: angle, radius: radius, fill: target.color}
+    return {angle: angle, radius: radius, fill: fill}
   })
 }
 

--- a/ring.js
+++ b/ring.js
@@ -18,7 +18,7 @@ function Ring(opts){
   var position = opts.position || [size/2, size/2]
   
   this.maxangle = opts.maxangle || 360
-  this.minangle = opts.minangle || 20
+  this.minangle = opts.minangle || 30
   this.maxdistance = opts.maxdistance || 100
 
   var notches = _.flatten(_.range(6).map(function (side) {

--- a/ring.js
+++ b/ring.js
@@ -18,7 +18,7 @@ function Ring(opts){
   var position = opts.position || [size/2, size/2]
   
   this.maxangle = opts.maxangle || 360
-  this.minangle = opts.minangle || 30
+  this.minangle = opts.minangle || 20
   this.maxdistance = opts.maxdistance || 100
 
   var notches = _.flatten(_.range(6).map(function (side) {
@@ -88,8 +88,7 @@ Ring.prototype.project = function(origin, targets) {
     if (angle < 0) angle += 360
     if (radius < .01) angle = 0
 
-    var interp = Math.max(1 - radius, 0.5)
-    var fill = color.interpolateHsl('rgb(55,55,55)', target.color)(interp)
+    var fill = color.interpolateHsl('rgb(55,55,55)', target.color)(0.85)
 
     return {angle: angle, radius: radius, fill: fill}
   })

--- a/ring.js
+++ b/ring.js
@@ -17,7 +17,7 @@ function Ring(opts){
   var size = opts.size || 50
   var position = opts.position || [size/2, size/2]
   
-  this.maxangle = opts.maxangle || 110
+  this.maxangle = opts.maxangle || 360
   this.minangle = opts.minangle || 20
   this.maxdistance = opts.maxdistance || 100
 
@@ -86,13 +86,12 @@ Ring.prototype.project = function(origin, targets) {
 
     angle -= offset
     if (angle < 0) angle += 360
-
-    var interp = Math.max(1 - radius, 0.5)
-    var fill = color.interpolateHsl('rgb(55,55,55)', target.color)(interp)
-    
     if (radius < .01) angle = 0
 
-    return {angle: angle, radius: radius, fill: fill}
+    //var interp = Math.max(1 - radius, 0.5)
+    //var fill = color.interpolateHsl('rgb(55,55,55)', target.color)(interp)
+
+    return {angle: angle, radius: radius, fill: target.color}
   })
 }
 
@@ -112,9 +111,11 @@ Ring.prototype.update = function(player, world) {
   }
 
   var colors = this.notches.map( function(notch, i) {
-    var fills = projections.map( function(p) {return discretize(i, p, self.notches.length)})
-    if (!_.any(fills)) return 'rgb(55,55,55)'
-    return _.min(_.remove(fills), function(f) {return f.radius}).fill.toString()
+    var fills = _.remove(projections.map( function(p) {return discretize(i, p, self.notches.length)}))
+    if (!fills.length) return 'rgb(55,55,55)'
+    var nonzero = _.filter(fills, function(f) {return f.radius > 0.2})
+    if (nonzero.length) return _.min(nonzero, function(f) {return f.radius}).fill.toString()
+    return fills[0].fill.toString() 
   })
 
   this.recolor(colors)


### PR DESCRIPTION
This PR adds support for a control scheme suggested by @mathisonian. In the new scheme, there are just three keys: A and D click left or right around the hexagon, and W moves forward. All three work within a tile, only A and D work inside a path (they flip you around).

The implementation is such that switching back to the previous version is now trivial, we just swap out

``` javascript
keymap: ['A', 'D', 'W']
heading: [-60, 60, 0]
shift: [0, 0, 8]
```

with

``` javascript
keymap: ['Q', 'W', 'E', 'A', 'S', 'D']
heading:[-60, 0, 60, -120, -180, 120]
shift: [8, 8, 8, 8, 8, 8]
```

the key idea is that `shift` is now an array of shifts, one per heading direction, and if a `shift` is 0 it means you don't move when heading in that direction.

Remaining todos:
- [x] switch to arrow keys (or at least make an option)
- [ ] reconsider what happens when you hit a wall (maybe bounce back to the center)
