### PR TITLE
Change module structure for transform

### DIFF
--- a/automove.js
+++ b/automove.js
@@ -1,6 +1,5 @@
 var _ = require('lodash')
 var inherits = require('inherits')
-var transform = require('./transform.js')
 var Fixmove = require('./fixmove.js')
 
 module.exports = Automove
@@ -50,10 +49,10 @@ Automove.prototype.seek = function (current, heading, offset) {
 
   return {
     position: [
-      this.shift * Math.sin((current.angle() + heading) * Math.PI / 180) + offset.position()[0], 
-      this.shift * -Math.cos((current.angle() + heading) * Math.PI / 180) + offset.position()[1]
+      this.shift * Math.sin((current.angle + heading) * Math.PI / 180) + offset.position[0], 
+      this.shift * -Math.cos((current.angle + heading) * Math.PI / 180) + offset.position[1]
     ], 
-    angle: current.angle() + heading
+    angle: current.angle + heading
   }
 }
 

--- a/camera.js
+++ b/camera.js
@@ -24,6 +24,6 @@ function Camera(opts){
 
 Camera.prototype.move = function(keyboard) {
   var self = this
-  var delta = self.movement.compute(keyboard.keysDown, self.transform.angle())
+  var delta = self.movement.compute(keyboard.keysDown, self.transform.angle)
   self.transform.compose(delta)
 }

--- a/freemove.js
+++ b/freemove.js
@@ -1,5 +1,4 @@
 var _ = require('lodash')
-var transform = require('./transform.js')
 
 function Freemove(data) {
   this.velocity = data.velocity || {position: [0, 0], angle: 0, scale: 0}

--- a/game.js
+++ b/game.js
@@ -68,21 +68,15 @@ player.on('update', function(interval) {
 });
 
 camera.on('update', function(interval) {
-  if (camera.yoked) {
-    camera.transform.set({
-      position: player.position(),
-      angle: player.angle()
-    })
-  }
+  if (camera.yoked) camera.transform.set({
+    position: player.position,
+    angle: player.angle
+  })
   this.move(keyboard)
 })
 
 ring.on('update', function(interval) {
   this.update(player, world)
-})
-
-world.on('location', function(msg) {
-  //console.log(msg)
 })
 
 game.on('update', function(interval){
@@ -96,7 +90,3 @@ game.on('draw', function(context) {
   mask.unset(context)
   ring.draw(context)
 })
-
-game.on('pause', function(){})
-
-game.on('resume', function(){})

--- a/geometry.js
+++ b/geometry.js
@@ -22,7 +22,7 @@ Geometry.prototype.stage = function(transform, opts) {
   opts = opts || {}
   transform = transform || self.transform
   op = opts.invert ? transform.invert : transform.apply
-  self.points = op(self.points)
+  self.points = op.bind(transform)(self.points)
   if (self.children.length) {
     _.forEach(self.children, function(child) {
       child.stage(transform, opts)
@@ -32,12 +32,7 @@ Geometry.prototype.stage = function(transform, opts) {
 
 Geometry.prototype.unstage = function() {
   var self = this
-  var t = transform({
-    position: self.transform.position(),
-    scale: self.transform.scale(),
-    angle: self.transform.angle()
-  })
-  self.stage(t, {invert: true})
+  self.stage(self.transform, {invert: true})
 }
 
 Geometry.prototype.update = function(transform) {
@@ -54,7 +49,7 @@ Geometry.prototype.contains = function(point) {
 
 Geometry.prototype.intersects = function(other) {
   var self = this
-  var response = new sat.Response();
+  var response = new sat.Response()
   var selfPoly = new sat.Polygon(
     new sat.Vector(), 
     self.points.map(function (xy) {return new sat.Vector(xy[0], xy[1])})
@@ -158,7 +153,7 @@ Geometry.prototype.drawSelf = function(context, camera) {
     points = points.map(function (xy) {
       return [xy[0] + camera.game.width/2, xy[1] + 2*camera.game.height/4]
     })
-    scale = camera.transform.scale()
+    scale = camera.transform.scale
   }
   if (this.props.type == 'polygon') this.drawPolygon(context, points, scale)
   if (this.props.type == 'bezier') this.drawBezier(context, points, scale)

--- a/player.js
+++ b/player.js
@@ -2,7 +2,6 @@ var _ = require('lodash')
 var inherits = require('inherits')
 var aabb = require('aabb-2d')
 var math = require('mathjs')
-var transform = require('./transform.js')
 var circle = require('./geo/circle.js')
 var Collision = require('./collision.js')
 var Fixmove = require('./fixmove.js')
@@ -43,14 +42,15 @@ function Player(opts){
   })
   this.collision = new Collision()
   this.waiting = true
+  this.update()
 }
 
 Player.prototype.move = function(keyboard, world) {
   var self = this
 
   var current = self.geometry.transform
-  var tile = world.tiles[world.locate(self.position())]
-  var inside =  tile.children[0].contains(current.position())
+  var tile = world.tiles[world.locate(self.position)]
+  var inside =  tile.children[0].contains(current.position)
   var keys = keyboard.keysDown
 
   var delta
@@ -58,7 +58,7 @@ Player.prototype.move = function(keyboard, world) {
     if (self.movement.tile.keypress(keys)) self.waiting = false
     if (self.waiting) {
       var center = {
-        position: [tile.transform.position()[0], tile.transform.position()[1]]
+        position: [tile.transform.position[0], tile.transform.position[1]]
       }
       delta = self.movement.center.compute(current, center)
     } else {
@@ -72,20 +72,16 @@ Player.prototype.move = function(keyboard, world) {
 
   self.geometry.update(delta)
   self.collision.handle(world, self.geometry, delta)
+  self.position = self.geometry.transform.position
+  self.update()
 }
 
 Player.prototype.draw = function(context, camera) {
   this.geometry.draw(context, camera, {order: 'bottom'})
 }
 
-Player.prototype.position = function() {
-  return this.geometry.transform.position()
-}
-
-Player.prototype.angle = function() {
-  return this.geometry.transform.angle()
-}
-
-Player.prototype.scale = function() {
-  return this.geometry.transform.scale()
+Player.prototype.update = function() {
+  this.position = this.geometry.transform.position
+  this.angle = this.geometry.transform.angle
+  this.scale = this.geometry.transform.scale
 }

--- a/ring.js
+++ b/ring.js
@@ -79,7 +79,7 @@ Ring.prototype.project = function(origin, targets) {
     angle = angle - 90
     if (angle < 0) angle += 360
 
-    var offset = -origin.angle() % 360
+    var offset = -origin.angle % 360
     if (offset < 0) offset += 360
     offset = 360 - offset
     if (offset == 360) offset = 0

--- a/world.js
+++ b/world.js
@@ -12,8 +12,6 @@ module.exports = World
 inherits(World, Entity)
 
 function World(opts) {
-  this.player = opts.player
-
   this.tiles = [
     tile({
       position: [0, 0],
@@ -85,15 +83,6 @@ function World(opts) {
       })]      
     })
   ]
-
-  this.on('update', function(interval) {
-    var self = this
-    var point = self.player.position()
-    var ind = self.locate(point)
-    if (self.tiles[ind].children[0].contains(point)) {
-      self.emit('location', 'inside tile ' + ind)
-    }
-  })
 }
 
 World.prototype.draw = function(context, camera) {
@@ -116,7 +105,7 @@ World.prototype.cues = function() {
   this.tiles.forEach(function (tile) {
     var cue = _.find(tile.children, function(child) {return child.props.cue})
     if (cue) cues.push({
-      position: tile.transform.position(), 
+      position: tile.transform.position, 
       color: cue.props.fill
     })
   })


### PR DESCRIPTION
This is a fairly minor change to the `transform` module pattern. The main reason for the change is that it prevents the slightly awkward use of getter functions in various places, i.e. `transform.position()` is now `transform.position`. Did some various cleanup of transform related code as well. 

With this done, I plan to split off `transform` into a separate module.
