### PR TITLE
Start and end events

### DIFF
--- a/game.js
+++ b/game.js
@@ -100,6 +100,10 @@ module.exports = function (canvas, schema, opts) {
     }
   })
 
+  game.on('start', function () {})
+
+  game.on('end', function () {})
+
   game.start()
 
   return {

--- a/game.js
+++ b/game.js
@@ -100,6 +100,8 @@ module.exports = function (canvas, schema, opts) {
     }
   })
 
+  game.start()
+
   return {
     reload: function (schema) {
       world.load(schema.tiles)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "crtrdg-entity": "^0.2.2",
-    "crtrdg-gameloop": "^0.2.2",
+    "crtrdg-gameloop": "^1.0.0",
     "crtrdg-keyboard": "0.0.2",
     "crtrdg-mouse": "~0.0.1",
     "crtrdg-player": "0.0.1",


### PR DESCRIPTION
updates to crtrdg-gameloop v1.0.0, which has `start` and `end` events triggered by `game.start()` and `game.end()` methods.
