### PR TITLE
fixes for flashing ring

### DIFF
--- a/entity/ring.js
+++ b/entity/ring.js
@@ -65,8 +65,16 @@ Ring.prototype.recolor = function (colors) {
   })
 }
 
-Ring.prototype.flash = function () {
+Ring.prototype.startFlashing = function () {
   this.flashing = true
+}
+
+Ring.prototype.stopFlashing = function () {
+  this.flashing = false
+}
+
+Ring.toggleFlashing = function () {
+  this.flashing ? this.stopFlashing() : this.startFlashing()
 }
 
 Ring.prototype.flashingColors = function () {
@@ -75,6 +83,10 @@ Ring.prototype.flashingColors = function () {
     var idx = Math.floor(Math.random() * colors.length) + 0
     notch.props.fill = colors[idx]
   })
+}
+
+Ring.prototype.reload = function () {
+  this.flashing = false
 }
 
 Ring.prototype.project = function (origin, targets) {

--- a/game.js
+++ b/game.js
@@ -96,7 +96,7 @@ module.exports = function (canvas, schema, opts) {
     if (targets.length > 0 && targets[0].contains(player.position())) {
       console.log('win!')
       console.log(schema.gameplay.timeout - time.seconds())
-      ring.flash()
+      ring.startFlashing()
     }
   })
 
@@ -110,6 +110,7 @@ module.exports = function (canvas, schema, opts) {
     reload: function (schema) {
       world.load(schema.tiles)
       player.load(schema.players[0])
+      ring.reload()
     },
 
     pause: function () {


### PR DESCRIPTION
- renames `ring.flash()` to `ring.startFlashing`
- adds `ring.stopFlashing()` and `ring.toggleFlashing()`
- adds `ring.reload()` which for now just makes sure the ring isn't flashing
- calls `ring.reload()` in `game.reload()`

because in the editor once the ring started flashing it would keep doing it until I took extreme annoying measures like refreshing the page
