### PR TITLE
Fix dead end

### DIFF
--- a/entity/player.js
+++ b/entity/player.js
@@ -62,7 +62,8 @@ Player.prototype.move = function (keyboard, world) {
   var keys = keyboard.keysDown
 
   var delta
-  
+  var correction
+
   if (inside) {
     if (self.movement.tile.keypress(keys)) self.waiting = false
     if (self.waiting) {
@@ -73,34 +74,33 @@ Player.prototype.move = function (keyboard, world) {
     } else {
       delta = self.movement.tile.compute(keys, current, tile.transform)
     }
-    
+
     self.geometry.update(delta)
-    var correction = self.collision.handle(world, self.geometry, delta)
+    correction = self.collision.handle(world, self.geometry, delta)
 
     if (correction) {
       self.geometry.update(correction)
       self.waiting = true
       self.movement.tile.reset()
-    } 
+    }
     self.movement.deadend.reset()
     self.reversing = false
-
   } else {
-    delta = self.movement.path.compute(keys, current) 
-    var correction = self.collision.handle(world, self.geometry, delta)
+    delta = self.movement.path.compute(keys, current)
+    correction = self.collision.handle(world, self.geometry, delta)
 
     if (correction && !self.reversing) {
       self.reversing = true
-      self.geometry.update(correction)      
+      self.geometry.update(correction)
     }
 
     if (self.reversing) {
-      delta = self.movement.deadend.compute(keys, current) 
+      delta = self.movement.deadend.compute(keys, current)
       self.geometry.update(delta)
     } else {
       self.geometry.update(delta)
     }
-    
+
     self.waiting = true
     self.movement.tile.reset()
   }

--- a/entity/player.js
+++ b/entity/player.js
@@ -26,14 +26,14 @@ function Player (schema, opts) {
     speed: opts.speed
   })
   this.movement.deadend = new Automove({
-    keymap: ['A', 'D', '<left>', '<right>'],
-    heading: [-180, 180, -180, 180],
-    shift: [0, 0, 0, 0],
-    speed: {translation: 0, rotation: opts.speed.rotation}
+    keymap: [],
+    heading: [],
+    shift: [],
+    speed: {translation: -opts.speed.translation, rotation: opts.speed.rotation}
   })
   this.collision = new Collision()
   this.waiting = true
-  this.turning = false
+  this.reversing = false
 }
 
 Player.prototype.load = function (schema) {
@@ -83,24 +83,21 @@ Player.prototype.move = function (keyboard, world) {
       self.movement.tile.reset()
     } 
     self.movement.deadend.reset()
-    self.turning = false
+    self.reversing = false
 
   } else {
     delta = self.movement.path.compute(keys, current) 
     var correction = self.collision.handle(world, self.geometry, delta)
 
-    if (correction && !self.turning) {
-      console.log('turning')
-      self.turning = true
+    if (correction && !self.reversing) {
+      self.reversing = true
       self.geometry.update(correction)      
     }
 
-    if (self.turning) {
-      console.log('deadend')
+    if (self.reversing) {
       delta = self.movement.deadend.compute(keys, current) 
       self.geometry.update(delta)
     } else {
-      console.log('free')
       self.geometry.update(delta)
     }
     

--- a/entity/player.js
+++ b/entity/player.js
@@ -34,14 +34,10 @@ function Player (schema, opts) {
   })
   this.collision = new Collision()
   this.waiting = true
-<<<<<<< HEAD
   this.reversing = false
-=======
-
   // this will usually cause an 'enter' event to be emitted at the start of a game
   this.inside = false
   this.moving = true
->>>>>>> master
 }
 
 Player.prototype.load = function (schema) {
@@ -85,6 +81,9 @@ Player.prototype.move = function (keyboard, world) {
 
   if (inside) {
     self.moving = false
+    self.movement.deadend.reset()
+    self.reversing = false
+
     if (self.movement.tile.keypress(keys)) self.waiting = false
     if (self.waiting) {
       var center = {
@@ -103,15 +102,11 @@ Player.prototype.move = function (keyboard, world) {
       self.waiting = true
       self.movement.tile.reset()
     }
-    self.movement.deadend.reset()
-    self.reversing = false
   } else {
-<<<<<<< HEAD
-=======
-    self.moving = true
     self.waiting = true
+    self.moving = true
     self.movement.tile.reset()
->>>>>>> master
+
     delta = self.movement.path.compute(keys, current)
     correction = self.collision.handle(world, self.geometry, delta)
 
@@ -126,9 +121,6 @@ Player.prototype.move = function (keyboard, world) {
     } else {
       self.geometry.update(delta)
     }
-
-    self.waiting = true
-    self.movement.tile.reset()
   }
 }
 

--- a/entity/player.js
+++ b/entity/player.js
@@ -29,10 +29,11 @@ function Player (schema, opts) {
     keymap: ['A', 'D', '<left>', '<right>'],
     heading: [-180, 180, -180, 180],
     shift: [0, 0, 0, 0],
-    speed: {translation: -2, rotation: opts.speed.rotation}
+    speed: {translation: 0, rotation: opts.speed.rotation}
   })
   this.collision = new Collision()
   this.waiting = true
+  this.turning = false
 }
 
 Player.prototype.load = function (schema) {
@@ -82,21 +83,28 @@ Player.prototype.move = function (keyboard, world) {
       self.movement.tile.reset()
     } 
     self.movement.deadend.reset()
+    self.turning = false
 
   } else {
     delta = self.movement.path.compute(keys, current) 
     var correction = self.collision.handle(world, self.geometry, delta)
-    
-    if (correction) {
+
+    if (correction && !self.turning) {
+      console.log('turning')
+      self.turning = true
+      self.geometry.update(correction)      
+    }
+
+    if (self.turning) {
       console.log('deadend')
       delta = self.movement.deadend.compute(keys, current) 
       self.geometry.update(delta)
     } else {
       console.log('free')
-      self.waiting = true
       self.geometry.update(delta)
     }
-
+    
+    self.waiting = true
     self.movement.tile.reset()
   }
 }

--- a/util/collision.js
+++ b/util/collision.js
@@ -13,9 +13,7 @@ Collision.prototype.handle = function (a, b, delta) {
     var ind = _.indexOf(results, _.max(results, function (i) { return i.response.overlap }))
     var overlap = results[ind].response.overlapV
     overlap = [overlap.x, overlap.y]
-    var correction = self.correct(delta, overlap)
-    b.update(correction)
-    return results[0].collision
+    return self.correct(delta, overlap)
   }
 
   return false
@@ -24,8 +22,8 @@ Collision.prototype.handle = function (a, b, delta) {
 Collision.prototype.correct = function (delta, overlap) {
   return {
     translation: [
-      -0.2 * delta.translation[0] + 0.5 * overlap[0],
-      -0.2 * delta.translation[1] + 0.5 * overlap[1]
+       -0.2 * delta.translation[0] + 0.5 * overlap[0],
+       -0.2 * delta.translation[1] + 0.5 * overlap[1]
     ]
   }
 }

--- a/util/collision.js
+++ b/util/collision.js
@@ -22,8 +22,8 @@ Collision.prototype.handle = function (a, b, delta) {
 Collision.prototype.correct = function (delta, overlap) {
   return {
     translation: [
-       -0.2 * delta.translation[0] + 0.5 * overlap[0],
-       -0.2 * delta.translation[1] + 0.5 * overlap[1]
+      -0.2 * delta.translation[0] + 0.5 * overlap[0],
+      -0.2 * delta.translation[1] + 0.5 * overlap[1]
     ]
   }
 }


### PR DESCRIPTION
Change movement behaviour such that no turning or backing up allowed in paths and auto bounce back in dead-ends.

This simplifies the user inputs such that they only get applied when inside the center hexagons. Movement between the tile centers is entirely deterministic even when hitting a dead-end
